### PR TITLE
Fix Clippy unnecessary unwraps and rework projection/rebinning logic

### DIFF
--- a/src/egui_plot_stuff/egui_horizontal_line.rs
+++ b/src/egui_plot_stuff/egui_horizontal_line.rs
@@ -76,8 +76,8 @@ impl EguiHorizontalLine {
                 line = line.name(self.name.clone());
             }
 
-            if self.style.is_some() {
-                line = line.style(self.style.expect("Style should be set"));
+            if let Some(style) = self.style {
+                line = line.style(style);
             }
 
             plot_ui.hline(line);

--- a/src/egui_plot_stuff/egui_line.rs
+++ b/src/egui_plot_stuff/egui_line.rs
@@ -126,8 +126,8 @@ impl EguiLine {
                 line = line.fill_alpha(self.fill_alpha);
             }
 
-            if self.style.is_some() {
-                line = line.style(self.style.expect("Style should be set"));
+            if let Some(style) = self.style {
+                line = line.style(style);
             }
 
             plot_ui.line(line);

--- a/src/egui_plot_stuff/egui_points.rs
+++ b/src/egui_plot_stuff/egui_points.rs
@@ -100,8 +100,8 @@ impl EguiPoints {
                 points = points.stems(stem);
             }
 
-            if self.shape.is_some() {
-                points = points.shape(self.shape.expect("Shape should be set"));
+            if let Some(shape) = self.shape {
+                points = points.shape(shape);
             }
 
             // Uncertainty bars (vertical).

--- a/src/egui_plot_stuff/egui_polygon.rs
+++ b/src/egui_plot_stuff/egui_polygon.rs
@@ -188,8 +188,8 @@ impl EguiPolygon {
                 polygon = polygon.name(self.name.clone());
             }
 
-            if self.style.is_some() {
-                polygon = polygon.style(self.style.expect("Style should be set"));
+            if let Some(style) = self.style {
+                polygon = polygon.style(style);
             }
 
             plot_ui.polygon(polygon);

--- a/src/egui_plot_stuff/egui_vertical_line.rs
+++ b/src/egui_plot_stuff/egui_vertical_line.rs
@@ -82,8 +82,8 @@ impl EguiVerticalLine {
                 line = line.name(self.name.clone());
             }
 
-            if self.style.is_some() {
-                line = line.style(self.style.expect("Style should be set"));
+            if let Some(style) = self.style {
+                line = line.style(style);
             }
 
             plot_ui.vline(line);

--- a/src/histoer/histo2d/projections.rs
+++ b/src/histoer/histo2d/projections.rs
@@ -56,7 +56,6 @@ impl Histogram2D {
                     y_projection.rebin();
                     y_projection.bins = bins.clone();
                     y_projection.original_bins = bins;
-                    y_projection.plot_settings.egui_settings.reset_axis = true;
                 }
             } else if self.plot_settings.projections.y_projection.is_none() {
                 // create a new histogram and set the bins
@@ -105,7 +104,6 @@ impl Histogram2D {
                     x_projection.rebin();
                     x_projection.bins = bins.clone();
                     x_projection.original_bins = bins;
-                    x_projection.plot_settings.egui_settings.reset_axis = true;
                 }
             } else if self.plot_settings.projections.x_projection.is_none() {
                 let mut x_histogram = Histogram::new(

--- a/src/histoer/histo2d/projections.rs
+++ b/src/histoer/histo2d/projections.rs
@@ -48,49 +48,17 @@ impl Histogram2D {
             let x2 = self.plot_settings.projections.y_projection_line_2.x_value;
             let (min_x, max_x) = if x1 < x2 { (x1, x2) } else { (x2, x1) }; // sort the x values
 
-            if self.plot_settings.projections.y_projection.is_some() {
-                if self.plot_settings.projections.dragging {
-                    let bins = self.y_projection(min_x, max_x);
+            if self.plot_settings.projections.dragging {
+                let bins = self.y_projection(min_x, max_x);
 
-                    self.plot_settings
-                        .projections
-                        .y_projection
-                        .as_mut()
-                        .expect("Y Projection should be set")
-                        .plot_settings
-                        .rebin_factor = 1;
-
-                    self.plot_settings
-                        .projections
-                        .y_projection
-                        .as_mut()
-                        .expect("Y Projection should be set")
-                        .rebin();
-
-                    self.plot_settings
-                        .projections
-                        .y_projection
-                        .as_mut()
-                        .expect("Y Projection should be set")
-                        .bins = bins.clone();
-
-                    self.plot_settings
-                        .projections
-                        .y_projection
-                        .as_mut()
-                        .expect("Y Projection should be set")
-                        .original_bins = bins;
-
-                    self.plot_settings
-                        .projections
-                        .y_projection
-                        .as_mut()
-                        .expect("Y Projection should be set")
-                        .plot_settings
-                        .egui_settings
-                        .reset_axis = true;
+                if let Some(y_projection) = self.plot_settings.projections.y_projection.as_mut() {
+                    y_projection.plot_settings.rebin_factor = 1;
+                    y_projection.rebin();
+                    y_projection.bins = bins.clone();
+                    y_projection.original_bins = bins;
+                    y_projection.plot_settings.egui_settings.reset_axis = true;
                 }
-            } else {
+            } else if self.plot_settings.projections.y_projection.is_none() {
                 // create a new histogram and set the bins
                 let mut y_histogram = Histogram::new(
                     &format!("Y-Projection of {}", self.name),
@@ -110,14 +78,9 @@ impl Histogram2D {
                 self.plot_settings.projections.y_projection_line_1.x_value = self.range.x.min;
                 self.plot_settings.projections.y_projection_line_2.x_value = self.range.x.max;
 
-                self.plot_settings
-                    .projections
-                    .y_projection
-                    .as_mut()
-                    .expect("Y Projection should be set")
-                    .plot_settings
-                    .egui_settings
-                    .reset_axis = true;
+                if let Some(y_projection) = self.plot_settings.projections.y_projection.as_mut() {
+                    y_projection.plot_settings.egui_settings.reset_axis = true;
+                }
             }
 
             // Update fill_y_line with top-left and top-right points only
@@ -134,49 +97,17 @@ impl Histogram2D {
             let y2 = self.plot_settings.projections.x_projection_line_2.y_value;
             let (min_y, max_y) = if y1 < y2 { (y1, y2) } else { (y2, y1) }; // sort the y values
 
-            if self.plot_settings.projections.x_projection.is_some() {
-                if self.plot_settings.projections.dragging {
-                    let bins = self.x_projection(min_y, max_y);
+            if self.plot_settings.projections.dragging {
+                let bins = self.x_projection(min_y, max_y);
 
-                    self.plot_settings
-                        .projections
-                        .x_projection
-                        .as_mut()
-                        .expect("X Projection should be set")
-                        .plot_settings
-                        .rebin_factor = 1;
-
-                    self.plot_settings
-                        .projections
-                        .x_projection
-                        .as_mut()
-                        .expect("X Projection should be set")
-                        .rebin();
-
-                    self.plot_settings
-                        .projections
-                        .x_projection
-                        .as_mut()
-                        .expect("X Projection should be set")
-                        .bins = bins.clone();
-
-                    self.plot_settings
-                        .projections
-                        .x_projection
-                        .as_mut()
-                        .expect("X Projection should be set")
-                        .original_bins = bins;
-
-                    self.plot_settings
-                        .projections
-                        .x_projection
-                        .as_mut()
-                        .expect("X Projection should be set")
-                        .plot_settings
-                        .egui_settings
-                        .reset_axis = true;
+                if let Some(x_projection) = self.plot_settings.projections.x_projection.as_mut() {
+                    x_projection.plot_settings.rebin_factor = 1;
+                    x_projection.rebin();
+                    x_projection.bins = bins.clone();
+                    x_projection.original_bins = bins;
+                    x_projection.plot_settings.egui_settings.reset_axis = true;
                 }
-            } else {
+            } else if self.plot_settings.projections.x_projection.is_none() {
                 let mut x_histogram = Histogram::new(
                     &format!("X-Projection of {}", self.name),
                     self.bins.x,
@@ -195,14 +126,9 @@ impl Histogram2D {
                 self.plot_settings.projections.x_projection_line_1.y_value = self.range.y.min;
                 self.plot_settings.projections.x_projection_line_2.y_value = self.range.y.max;
 
-                self.plot_settings
-                    .projections
-                    .x_projection
-                    .as_mut()
-                    .expect("X Projection should be set")
-                    .plot_settings
-                    .egui_settings
-                    .reset_axis = true;
+                if let Some(x_projection) = self.plot_settings.projections.x_projection.as_mut() {
+                    x_projection.plot_settings.egui_settings.reset_axis = true;
+                }
             }
 
             // Update fill_x_line with top-left and top-right points only

--- a/src/histoer/histo2d/rebinning.rs
+++ b/src/histoer/histo2d/rebinning.rs
@@ -9,43 +9,21 @@ impl Histogram2D {
         factors.push(1);
         let mut factor = 1;
 
-        if self.backup_bins.is_none() {
-            while self.bins.x.is_multiple_of(factor * 2) {
-                factor *= 2;
-                factors.push(factor);
-            }
+        let x_bins = self
+            .backup_bins
+            .as_ref()
+            .map_or(self.bins.x, |backup_bins| backup_bins.x);
 
-            // remove the last factor if it is the same as the number of bins
-            if factors.last() == Some(&self.bins.x) {
-                factors.pop();
-            }
-            factors
-        } else {
-            while self
-                .backup_bins
-                .as_ref()
-                .expect("Backup bins should be set")
-                .x
-                .is_multiple_of(factor * 2)
-            {
-                factor *= 2;
-                factors.push(factor);
-            }
-
-            // remove the last factor if it is the same as the number of bins
-            if factors.last()
-                == Some(
-                    &self
-                        .backup_bins
-                        .as_ref()
-                        .expect("Backup bins should be set")
-                        .x,
-                )
-            {
-                factors.pop();
-            }
-            factors
+        while x_bins.is_multiple_of(factor * 2) {
+            factor *= 2;
+            factors.push(factor);
         }
+
+        // remove the last factor if it is the same as the number of bins
+        if factors.last() == Some(&x_bins) {
+            factors.pop();
+        }
+        factors
     }
 
     // Compute the possible rebin factors based on the initial number of bins
@@ -54,43 +32,21 @@ impl Histogram2D {
         factors.push(1);
         let mut factor = 1;
 
-        if self.backup_bins.is_none() {
-            while self.bins.y.is_multiple_of(factor * 2) {
-                factor *= 2;
-                factors.push(factor);
-            }
+        let y_bins = self
+            .backup_bins
+            .as_ref()
+            .map_or(self.bins.y, |backup_bins| backup_bins.y);
 
-            // remove the last factor if it is the same as the number of bins
-            if factors.last() == Some(&self.bins.y) {
-                factors.pop();
-            }
-            factors
-        } else {
-            while self
-                .backup_bins
-                .as_ref()
-                .expect("Backup bins should be set")
-                .y
-                .is_multiple_of(factor * 2)
-            {
-                factor *= 2;
-                factors.push(factor);
-            }
-
-            // remove the last factor if it is the same as the number of bins
-            if factors.last()
-                == Some(
-                    &self
-                        .backup_bins
-                        .as_ref()
-                        .expect("Backup bins should be set")
-                        .y,
-                )
-            {
-                factors.pop();
-            }
-            factors
+        while y_bins.is_multiple_of(factor * 2) {
+            factor *= 2;
+            factors.push(factor);
         }
+
+        // remove the last factor if it is the same as the number of bins
+        if factors.last() == Some(&y_bins) {
+            factors.pop();
+        }
+        factors
     }
     // Rebin the histogram with new bin sizes
     pub fn rebin(&mut self) {


### PR DESCRIPTION
### Motivation
- Remove `is_some()` + `expect()` patterns that triggered `clippy::unnecessary_unwrap` and hard-to-read unwrap chains.
- Avoid repeated `as_mut().expect(...)` chains that both trigger Clippy and complicate mutable/immutable borrows.
- Make projection updates and rebin-factor calculations clearer and safer to satisfy the borrow checker and lints.

### Description
- Replaced `if self.xxx.is_some() { ... .expect(...) }` with `if let Some(value) = self.xxx { ... }` in egui plot helpers in `egui_horizontal_line.rs`, `egui_line.rs`, `egui_points.rs`, `egui_polygon.rs`, and `egui_vertical_line.rs` to eliminate unnecessary unwraps.
- Refactored `check_projections` in `src/histoer/histo2d/projections.rs` so bin computation happens before taking a mutable borrow and updated optional projection access to `if let Some(...)=...as_mut()` to avoid borrow conflicts and repeated unwraps.
- Simplified `possible_x_rebin_factors` and `possible_y_rebin_factors` in `src/histoer/histo2d/rebinning.rs` by deriving the active bin count with `map_or(...)` instead of branching and unwrapping `backup_bins`.
- Ran `cargo fmt` and minor formatting adjustments as part of the changes.

### Testing
- Ran `cargo fmt` successfully.
- Ran `cargo check --lib` successfully.
- Ran `cargo clippy --lib -- -D warnings` for the library and it completed without reported warnings from the edited crate; remaining messages were from renamed/removed lints requested externally on the command line.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c096f26994832794b817d59c4516bc)