### PR TITLE
Initialize projections from current view and inset handles for easier dragging

### DIFF
--- a/src/histoer/histo2d/context_menu.rs
+++ b/src/histoer/histo2d/context_menu.rs
@@ -1,4 +1,5 @@
 use super::histogram2d::Histogram2D;
+use super::projections::ProjectionAxisSettings;
 use crate::histoer::cuts::Cut2D;
 
 use egui::Color32;
@@ -42,7 +43,18 @@ impl Histogram2D {
                 self.image.menu_button(ui);
             });
 
-        self.plot_settings.settings_ui(ui, self.bins.max_count);
+        self.plot_settings.settings_ui(
+            ui,
+            self.bins.max_count,
+            ProjectionAxisSettings {
+                axis_range: (self.range.x.min, self.range.x.max),
+                bin_width: self.bins.x_width,
+            },
+            ProjectionAxisSettings {
+                axis_range: (self.range.y.min, self.range.y.max),
+                bin_width: self.bins.y_width,
+            },
+        );
 
         SubMenuButton::new("Cuts")
             .config(MenuConfig::new().close_behavior(PopupCloseBehavior::CloseOnClickOutside))

--- a/src/histoer/histo2d/histogram2d.rs
+++ b/src/histoer/histo2d/histogram2d.rs
@@ -252,6 +252,12 @@ impl Histogram2D {
     fn draw(&mut self, plot_ui: &mut egui_plot::PlotUi<'_>) {
         self.show_stats(plot_ui);
 
+        let plot_bounds = plot_ui.plot_bounds();
+        self.plot_settings.projections.current_plot_bounds = Some((
+            (plot_bounds.min()[0], plot_bounds.max()[0]),
+            (plot_bounds.min()[1], plot_bounds.max()[1]),
+        ));
+
         let heatmap_image = self.image.get_plot_image_from_texture();
 
         if let Some(image) = heatmap_image {

--- a/src/histoer/histo2d/plot_settings.rs
+++ b/src/histoer/histo2d/plot_settings.rs
@@ -3,7 +3,7 @@ use crate::histoer::cuts::Cut2D;
 use crate::egui_plot_stuff::egui_plot_settings::EguiPlotSettings;
 
 use super::colormaps::{ColorMap, ColormapOptions};
-use super::projections::Projections;
+use super::projections::{ProjectionAxisSettings, Projections};
 
 use egui::PopupCloseBehavior;
 use egui::containers::menu::{MenuConfig, SubMenuButton};
@@ -44,7 +44,13 @@ impl Default for PlotSettings {
     }
 }
 impl PlotSettings {
-    pub fn settings_ui(&mut self, ui: &mut egui::Ui, max_z_range: u64) {
+    pub fn settings_ui(
+        &mut self,
+        ui: &mut egui::Ui,
+        max_z_range: u64,
+        x_axis_settings: ProjectionAxisSettings,
+        y_axis_settings: ProjectionAxisSettings,
+    ) {
         SubMenuButton::new("Colormaps")
             .config(MenuConfig::new().close_behavior(PopupCloseBehavior::CloseOnClickOutside))
             .ui(ui, |ui| {
@@ -65,7 +71,8 @@ impl PlotSettings {
         SubMenuButton::new("Projections")
             .config(MenuConfig::new().close_behavior(PopupCloseBehavior::CloseOnClickOutside))
             .ui(ui, |ui| {
-                self.projections.menu_button(ui);
+                self.projections
+                    .menu_button(ui, x_axis_settings, y_axis_settings);
             });
     }
 

--- a/src/histoer/histo2d/projections.rs
+++ b/src/histoer/histo2d/projections.rs
@@ -4,7 +4,6 @@ use crate::egui_plot_stuff::egui_horizontal_line::EguiHorizontalLine;
 use crate::egui_plot_stuff::egui_line::EguiLine;
 use crate::egui_plot_stuff::egui_vertical_line::EguiVerticalLine;
 use crate::histoer::histo1d::histogram1d::Histogram;
-use egui::Id;
 
 use super::histogram2d::Histogram2D;
 
@@ -170,17 +169,16 @@ pub struct Projections {
     #[serde(skip)]
     pub current_plot_bounds: Option<((f64, f64), (f64, f64))>,
     #[serde(skip)]
-    pub y_center_dragging: bool,
+    pub y_area_dragging: bool,
     #[serde(skip)]
-    pub x_center_dragging: bool,
+    pub x_area_dragging: bool,
+    #[serde(skip)]
+    pub y_drag_anchor: Option<f64>,
+    #[serde(skip)]
+    pub x_drag_anchor: Option<f64>,
 }
 impl Projections {
     const DEFAULT_AXIS_OFFSET_FRACTION: f64 = 0.05;
-    const CENTER_HANDLE_RADIUS: f32 = 6.0;
-    const Y_CENTER_HANDLE_ID: &'static str = "Y Projection Center Handle";
-    const Y_CENTER_CONNECTOR_ID: &'static str = "Y Projection Center Connector";
-    const X_CENTER_HANDLE_ID: &'static str = "X Projection Center Handle";
-    const X_CENTER_CONNECTOR_ID: &'static str = "X Projection Center Connector";
 
     pub fn new() -> Self {
         Self {
@@ -235,8 +233,10 @@ impl Projections {
             },
             dragging: false,
             current_plot_bounds: None,
-            y_center_dragging: false,
-            x_center_dragging: false,
+            y_area_dragging: false,
+            x_area_dragging: false,
+            y_drag_anchor: None,
+            x_drag_anchor: None,
         }
     }
 
@@ -337,52 +337,6 @@ impl Projections {
         }
     }
 
-    fn draw_y_center_handle(&mut self, plot_ui: &mut egui_plot::PlotUi<'_>) {
-        let y_mid = (plot_ui.plot_bounds().min()[1] + plot_ui.plot_bounds().max()[1]) / 2.0;
-        let x1 = self.y_projection_line_1.x_value;
-        let x2 = self.y_projection_line_2.x_value;
-        let center_x = self.y_projection_center();
-
-        let connector = egui_plot::Line::new(
-            "",
-            egui_plot::PlotPoints::Owned(vec![[x1, y_mid].into(), [x2, y_mid].into()]),
-        )
-        .color(self.y_projection_line_1.color)
-        .width(2.0)
-        .allow_hover(false)
-        .id(Id::new(Self::Y_CENTER_CONNECTOR_ID));
-        plot_ui.line(connector);
-
-        let center_point = egui_plot::Points::new("", vec![[center_x, y_mid]])
-            .color(self.y_projection_line_1.color)
-            .radius(Self::CENTER_HANDLE_RADIUS)
-            .id(Id::new(Self::Y_CENTER_HANDLE_ID));
-        plot_ui.points(center_point);
-    }
-
-    fn draw_x_center_handle(&mut self, plot_ui: &mut egui_plot::PlotUi<'_>) {
-        let x_mid = (plot_ui.plot_bounds().min()[0] + plot_ui.plot_bounds().max()[0]) / 2.0;
-        let y1 = self.x_projection_line_1.y_value;
-        let y2 = self.x_projection_line_2.y_value;
-        let center_y = self.x_projection_center();
-
-        let connector = egui_plot::Line::new(
-            "",
-            egui_plot::PlotPoints::Owned(vec![[x_mid, y1].into(), [x_mid, y2].into()]),
-        )
-        .color(self.x_projection_line_1.color)
-        .width(2.0)
-        .allow_hover(false)
-        .id(Id::new(Self::X_CENTER_CONNECTOR_ID));
-        plot_ui.line(connector);
-
-        let center_point = egui_plot::Points::new("", vec![[x_mid, center_y]])
-            .color(self.x_projection_line_1.color)
-            .radius(Self::CENTER_HANDLE_RADIUS)
-            .id(Id::new(Self::X_CENTER_HANDLE_ID));
-        plot_ui.points(center_point);
-    }
-
     fn show_y_projection(&mut self, ui: &egui::Ui) {
         if self.add_y_projection && self.y_projection.is_some() {
             let name = if let Some(histogram) = &self.y_projection {
@@ -425,11 +379,11 @@ impl Projections {
         self.dragging = (self.add_y_projection
             && (self.y_projection_line_1.is_dragging
                 || self.y_projection_line_2.is_dragging
-                || self.y_center_dragging))
+                || self.y_area_dragging))
             || (self.add_x_projection
                 && (self.x_projection_line_1.is_dragging
                     || self.x_projection_line_2.is_dragging
-                    || self.x_center_dragging));
+                    || self.x_area_dragging));
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
@@ -441,14 +395,12 @@ impl Projections {
         if self.add_y_projection {
             self.y_projection_line_1.draw(plot_ui, None);
             self.y_projection_line_2.draw(plot_ui, None);
-            self.draw_y_center_handle(plot_ui);
             self.fill_y_line.draw(plot_ui, None);
         }
 
         if self.add_x_projection {
             self.x_projection_line_1.draw(plot_ui);
             self.x_projection_line_2.draw(plot_ui);
-            self.draw_x_center_handle(plot_ui);
             self.fill_x_line.draw(plot_ui, None);
         }
 
@@ -462,82 +414,112 @@ impl Projections {
             self.y_projection_line_2
                 .interactive_dragging(plot_response, None);
             if self.y_projection_line_1.is_dragging || self.y_projection_line_2.is_dragging {
-                self.y_center_dragging = false;
+                self.y_area_dragging = false;
+                self.y_drag_anchor = None;
             }
-            self.interactive_drag_y_projection_center(plot_response);
+            self.interactive_drag_y_projection_area(plot_response);
         }
 
         if self.add_x_projection {
             self.x_projection_line_1.interactive_dragging(plot_response);
             self.x_projection_line_2.interactive_dragging(plot_response);
             if self.x_projection_line_1.is_dragging || self.x_projection_line_2.is_dragging {
-                self.x_center_dragging = false;
+                self.x_area_dragging = false;
+                self.x_drag_anchor = None;
             }
-            self.interactive_drag_x_projection_center(plot_response);
+            self.interactive_drag_x_projection_area(plot_response);
         }
     }
 
-    fn interactive_drag_y_projection_center(
-        &mut self,
-        plot_response: &egui_plot::PlotResponse<()>,
-    ) {
+    fn interactive_drag_y_projection_area(&mut self, plot_response: &egui_plot::PlotResponse<()>) {
         let pointer_state = plot_response.response.ctx.input(|i| i.pointer.clone());
         if let Some(pointer_pos) = pointer_state.hover_pos() {
-            if let Some(hovered_id) = plot_response.hovered_plot_item
-                && hovered_id == Id::new(Self::Y_CENTER_HANDLE_ID)
-                && pointer_state.button_pressed(egui::PointerButton::Primary)
+            let pointer = plot_response.transform.value_from_position(pointer_pos);
+            let min_x = self
+                .y_projection_line_1
+                .x_value
+                .min(self.y_projection_line_2.x_value);
+            let max_x = self
+                .y_projection_line_1
+                .x_value
+                .max(self.y_projection_line_2.x_value);
+
+            if pointer_state.button_pressed(egui::PointerButton::Primary)
+                && !self.y_projection_line_1.is_dragging
+                && !self.y_projection_line_2.is_dragging
+                && pointer.x >= min_x
+                && pointer.x <= max_x
             {
-                self.y_center_dragging = true;
+                self.y_area_dragging = true;
+                self.y_drag_anchor = Some(pointer.x);
             }
 
-            if self.y_center_dragging {
+            if self.y_area_dragging {
                 if let Some(((x_min, x_max), _)) = self.current_plot_bounds {
-                    let center = plot_response.transform.value_from_position(pointer_pos).x;
+                    let center = self.y_projection_center();
+                    let delta = pointer.x - self.y_drag_anchor.unwrap_or(pointer.x);
                     self.set_y_projection_center_and_width(
-                        center,
+                        center + delta,
                         self.y_projection_width(),
                         (x_min, x_max),
                     );
+                    self.y_drag_anchor = Some(pointer.x);
                 }
 
                 if pointer_state.button_released(egui::PointerButton::Primary) {
-                    self.y_center_dragging = false;
+                    self.y_area_dragging = false;
+                    self.y_drag_anchor = None;
                 }
             }
         } else if pointer_state.button_released(egui::PointerButton::Primary) {
-            self.y_center_dragging = false;
+            self.y_area_dragging = false;
+            self.y_drag_anchor = None;
         }
     }
 
-    fn interactive_drag_x_projection_center(
-        &mut self,
-        plot_response: &egui_plot::PlotResponse<()>,
-    ) {
+    fn interactive_drag_x_projection_area(&mut self, plot_response: &egui_plot::PlotResponse<()>) {
         let pointer_state = plot_response.response.ctx.input(|i| i.pointer.clone());
         if let Some(pointer_pos) = pointer_state.hover_pos() {
-            if let Some(hovered_id) = plot_response.hovered_plot_item
-                && hovered_id == Id::new(Self::X_CENTER_HANDLE_ID)
-                && pointer_state.button_pressed(egui::PointerButton::Primary)
+            let pointer = plot_response.transform.value_from_position(pointer_pos);
+            let min_y = self
+                .x_projection_line_1
+                .y_value
+                .min(self.x_projection_line_2.y_value);
+            let max_y = self
+                .x_projection_line_1
+                .y_value
+                .max(self.x_projection_line_2.y_value);
+
+            if pointer_state.button_pressed(egui::PointerButton::Primary)
+                && !self.x_projection_line_1.is_dragging
+                && !self.x_projection_line_2.is_dragging
+                && pointer.y >= min_y
+                && pointer.y <= max_y
             {
-                self.x_center_dragging = true;
+                self.x_area_dragging = true;
+                self.x_drag_anchor = Some(pointer.y);
             }
 
-            if self.x_center_dragging {
+            if self.x_area_dragging {
                 if let Some((_, (y_min, y_max))) = self.current_plot_bounds {
-                    let center = plot_response.transform.value_from_position(pointer_pos).y;
+                    let center = self.x_projection_center();
+                    let delta = pointer.y - self.x_drag_anchor.unwrap_or(pointer.y);
                     self.set_x_projection_center_and_width(
-                        center,
+                        center + delta,
                         self.x_projection_width(),
                         (y_min, y_max),
                     );
+                    self.x_drag_anchor = Some(pointer.y);
                 }
 
                 if pointer_state.button_released(egui::PointerButton::Primary) {
-                    self.x_center_dragging = false;
+                    self.x_area_dragging = false;
+                    self.x_drag_anchor = None;
                 }
             }
         } else if pointer_state.button_released(egui::PointerButton::Primary) {
-            self.x_center_dragging = false;
+            self.x_area_dragging = false;
+            self.x_drag_anchor = None;
         }
     }
 

--- a/src/histoer/histo2d/projections.rs
+++ b/src/histoer/histo2d/projections.rs
@@ -4,8 +4,15 @@ use crate::egui_plot_stuff::egui_horizontal_line::EguiHorizontalLine;
 use crate::egui_plot_stuff::egui_line::EguiLine;
 use crate::egui_plot_stuff::egui_vertical_line::EguiVerticalLine;
 use crate::histoer::histo1d::histogram1d::Histogram;
+use egui::Id;
 
 use super::histogram2d::Histogram2D;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ProjectionAxisSettings {
+    pub axis_range: (f64, f64),
+    pub bin_width: f64,
+}
 
 impl Histogram2D {
     pub fn y_projection(&self, x_min: f64, x_max: f64) -> Vec<u64> {
@@ -162,9 +169,16 @@ pub struct Projections {
     pub dragging: bool,
     #[serde(skip)]
     pub current_plot_bounds: Option<((f64, f64), (f64, f64))>,
+    #[serde(skip)]
+    pub y_center_dragging: bool,
+    #[serde(skip)]
+    pub x_center_dragging: bool,
 }
 impl Projections {
     const DEFAULT_AXIS_OFFSET_FRACTION: f64 = 0.05;
+    const CENTER_HANDLE_RADIUS: f32 = 6.0;
+    const Y_CENTER_HANDLE_ID: &'static str = "Y Projection Center Handle";
+    const X_CENTER_HANDLE_ID: &'static str = "X Projection Center Handle";
 
     pub fn new() -> Self {
         Self {
@@ -219,6 +233,8 @@ impl Projections {
             },
             dragging: false,
             current_plot_bounds: None,
+            y_center_dragging: false,
+            x_center_dragging: false,
         }
     }
 
@@ -251,6 +267,116 @@ impl Projections {
 
         self.x_projection_line_1.y_value = y_min + offset;
         self.x_projection_line_2.y_value = y_max - offset;
+    }
+
+    fn clamp_projection_center(center: f64, width: f64, axis_range: (f64, f64)) -> f64 {
+        let half_width = width / 2.0;
+        let min_center = axis_range.0 + half_width;
+        let max_center = axis_range.1 - half_width;
+
+        if min_center > max_center {
+            (axis_range.0 + axis_range.1) / 2.0
+        } else {
+            center.clamp(min_center, max_center)
+        }
+    }
+
+    fn y_projection_width(&self) -> f64 {
+        (self.y_projection_line_2.x_value - self.y_projection_line_1.x_value).abs()
+    }
+
+    fn x_projection_width(&self) -> f64 {
+        (self.x_projection_line_2.y_value - self.x_projection_line_1.y_value).abs()
+    }
+
+    fn y_projection_center(&self) -> f64 {
+        (self.y_projection_line_1.x_value + self.y_projection_line_2.x_value) / 2.0
+    }
+
+    fn x_projection_center(&self) -> f64 {
+        (self.x_projection_line_1.y_value + self.x_projection_line_2.y_value) / 2.0
+    }
+
+    fn set_y_projection_center_and_width(
+        &mut self,
+        center: f64,
+        width: f64,
+        axis_range: (f64, f64),
+    ) {
+        let max_width = (axis_range.1 - axis_range.0).abs();
+        let clamped_width = width.clamp(0.0, max_width);
+        let center = Self::clamp_projection_center(center, clamped_width, axis_range);
+        let half_width = clamped_width / 2.0;
+
+        self.y_projection_line_1.x_value = center - half_width;
+        self.y_projection_line_2.x_value = center + half_width;
+    }
+
+    fn set_x_projection_center_and_width(
+        &mut self,
+        center: f64,
+        width: f64,
+        axis_range: (f64, f64),
+    ) {
+        let max_width = (axis_range.1 - axis_range.0).abs();
+        let clamped_width = width.clamp(0.0, max_width);
+        let center = Self::clamp_projection_center(center, clamped_width, axis_range);
+        let half_width = clamped_width / 2.0;
+
+        self.x_projection_line_1.y_value = center - half_width;
+        self.x_projection_line_2.y_value = center + half_width;
+    }
+
+    fn projection_bins(width: f64, bin_width: f64) -> usize {
+        if bin_width <= 0.0 {
+            0
+        } else {
+            (width / bin_width).round().max(0.0) as usize
+        }
+    }
+
+    fn draw_y_center_handle(&mut self, plot_ui: &mut egui_plot::PlotUi<'_>) {
+        let y_mid = (plot_ui.plot_bounds().min()[1] + plot_ui.plot_bounds().max()[1]) / 2.0;
+        let x1 = self.y_projection_line_1.x_value;
+        let x2 = self.y_projection_line_2.x_value;
+        let center_x = self.y_projection_center();
+
+        let connector = egui_plot::Line::new(
+            "",
+            egui_plot::PlotPoints::Owned(vec![[x1, y_mid].into(), [x2, y_mid].into()]),
+        )
+        .color(self.y_projection_line_1.color)
+        .width(2.0)
+        .id(Id::new(Self::Y_CENTER_HANDLE_ID));
+        plot_ui.line(connector);
+
+        let center_point = egui_plot::Points::new("", vec![[center_x, y_mid]])
+            .color(self.y_projection_line_1.color)
+            .radius(Self::CENTER_HANDLE_RADIUS)
+            .id(Id::new(Self::Y_CENTER_HANDLE_ID));
+        plot_ui.points(center_point);
+    }
+
+    fn draw_x_center_handle(&mut self, plot_ui: &mut egui_plot::PlotUi<'_>) {
+        let x_mid = (plot_ui.plot_bounds().min()[0] + plot_ui.plot_bounds().max()[0]) / 2.0;
+        let y1 = self.x_projection_line_1.y_value;
+        let y2 = self.x_projection_line_2.y_value;
+        let center_y = self.x_projection_center();
+
+        let connector = egui_plot::Line::new(
+            "",
+            egui_plot::PlotPoints::Owned(vec![[x_mid, y1].into(), [x_mid, y2].into()]),
+        )
+        .color(self.x_projection_line_1.color)
+        .width(2.0)
+        .id(Id::new(Self::X_CENTER_HANDLE_ID));
+        plot_ui.line(connector);
+
+        let center_point = egui_plot::Points::new("", vec![[x_mid, center_y]])
+            .color(self.x_projection_line_1.color)
+            .radius(Self::CENTER_HANDLE_RADIUS)
+            .id(Id::new(Self::X_CENTER_HANDLE_ID));
+        plot_ui.points(center_point);
     }
 
     fn show_y_projection(&mut self, ui: &egui::Ui) {
@@ -293,9 +419,13 @@ impl Projections {
 
     pub fn is_dragging(&mut self) {
         self.dragging = (self.add_y_projection
-            && (self.y_projection_line_1.is_dragging || self.y_projection_line_2.is_dragging))
+            && (self.y_projection_line_1.is_dragging
+                || self.y_projection_line_2.is_dragging
+                || self.y_center_dragging))
             || (self.add_x_projection
-                && (self.x_projection_line_1.is_dragging || self.x_projection_line_2.is_dragging));
+                && (self.x_projection_line_1.is_dragging
+                    || self.x_projection_line_2.is_dragging
+                    || self.x_center_dragging));
     }
 
     pub fn show(&mut self, ui: &mut egui::Ui) {
@@ -307,12 +437,14 @@ impl Projections {
         if self.add_y_projection {
             self.y_projection_line_1.draw(plot_ui, None);
             self.y_projection_line_2.draw(plot_ui, None);
+            self.draw_y_center_handle(plot_ui);
             self.fill_y_line.draw(plot_ui, None);
         }
 
         if self.add_x_projection {
             self.x_projection_line_1.draw(plot_ui);
             self.x_projection_line_2.draw(plot_ui);
+            self.draw_x_center_handle(plot_ui);
             self.fill_x_line.draw(plot_ui, None);
         }
 
@@ -325,29 +457,150 @@ impl Projections {
                 .interactive_dragging(plot_response, None);
             self.y_projection_line_2
                 .interactive_dragging(plot_response, None);
+            self.interactive_drag_y_projection_center(plot_response);
         }
 
         if self.add_x_projection {
             self.x_projection_line_1.interactive_dragging(plot_response);
             self.x_projection_line_2.interactive_dragging(plot_response);
+            self.interactive_drag_x_projection_center(plot_response);
         }
     }
 
-    pub fn menu_button(&mut self, ui: &mut egui::Ui) {
+    fn interactive_drag_y_projection_center(
+        &mut self,
+        plot_response: &egui_plot::PlotResponse<()>,
+    ) {
+        let pointer_state = plot_response.response.ctx.input(|i| i.pointer.clone());
+        if let Some(pointer_pos) = pointer_state.hover_pos() {
+            if let Some(hovered_id) = plot_response.hovered_plot_item
+                && hovered_id == Id::new(Self::Y_CENTER_HANDLE_ID)
+                && pointer_state.button_pressed(egui::PointerButton::Primary)
+            {
+                self.y_center_dragging = true;
+            }
+
+            if self.y_center_dragging {
+                if let Some(((x_min, x_max), _)) = self.current_plot_bounds {
+                    let center = plot_response.transform.value_from_position(pointer_pos).x;
+                    self.set_y_projection_center_and_width(
+                        center,
+                        self.y_projection_width(),
+                        (x_min, x_max),
+                    );
+                }
+
+                if pointer_state.button_released(egui::PointerButton::Primary) {
+                    self.y_center_dragging = false;
+                }
+            }
+        } else if pointer_state.button_released(egui::PointerButton::Primary) {
+            self.y_center_dragging = false;
+        }
+    }
+
+    fn interactive_drag_x_projection_center(
+        &mut self,
+        plot_response: &egui_plot::PlotResponse<()>,
+    ) {
+        let pointer_state = plot_response.response.ctx.input(|i| i.pointer.clone());
+        if let Some(pointer_pos) = pointer_state.hover_pos() {
+            if let Some(hovered_id) = plot_response.hovered_plot_item
+                && hovered_id == Id::new(Self::X_CENTER_HANDLE_ID)
+                && pointer_state.button_pressed(egui::PointerButton::Primary)
+            {
+                self.x_center_dragging = true;
+            }
+
+            if self.x_center_dragging {
+                if let Some((_, (y_min, y_max))) = self.current_plot_bounds {
+                    let center = plot_response.transform.value_from_position(pointer_pos).y;
+                    self.set_x_projection_center_and_width(
+                        center,
+                        self.x_projection_width(),
+                        (y_min, y_max),
+                    );
+                }
+
+                if pointer_state.button_released(egui::PointerButton::Primary) {
+                    self.x_center_dragging = false;
+                }
+            }
+        } else if pointer_state.button_released(egui::PointerButton::Primary) {
+            self.x_center_dragging = false;
+        }
+    }
+
+    fn projection_width_controls(
+        ui: &mut egui::Ui,
+        enabled: bool,
+        label: &str,
+        center: f64,
+        width: f64,
+        axis_settings: ProjectionAxisSettings,
+    ) -> Option<(f64, f64)> {
+        let mut next_width = width;
+        let mut width_bins = Self::projection_bins(width, axis_settings.bin_width);
+        let mut changed = false;
+
+        ui.vertical(|ui| {
+            ui.label(label);
+            ui.horizontal(|ui| {
+                ui.label("Width:");
+                changed |= ui
+                    .add_enabled(
+                        enabled,
+                        egui::DragValue::new(&mut width_bins)
+                            .range(0..=usize::MAX)
+                            .speed(1.0)
+                            .suffix(" bins"),
+                    )
+                    .changed();
+
+                changed |= ui
+                    .add_enabled(
+                        enabled,
+                        egui::DragValue::new(&mut next_width)
+                            .range(
+                                0.0..=((axis_settings.axis_range.1 - axis_settings.axis_range.0)
+                                    .abs()),
+                            )
+                            .speed(axis_settings.bin_width.max(0.1))
+                            .prefix("range: "),
+                    )
+                    .changed();
+            });
+        });
+
+        if changed {
+            let bins_width = width_bins as f64 * axis_settings.bin_width;
+            let width_from_range = next_width;
+            let width = if (width_from_range - width).abs() > f64::EPSILON {
+                width_from_range
+            } else {
+                bins_width
+            };
+            Some((center, width))
+        } else {
+            None
+        }
+    }
+
+    pub fn menu_button(
+        &mut self,
+        ui: &mut egui::Ui,
+        x_axis_settings: ProjectionAxisSettings,
+        y_axis_settings: ProjectionAxisSettings,
+    ) {
         ui.heading("Projections");
 
         ui.horizontal(|ui| {
             ui.checkbox(&mut self.add_y_projection, "Add Y Projection").on_hover_text("Keybinds:\nY = Add Y Projection\nLeft click and drag the line at the center of the plot (cirlce)");
 
-            let range = if let Some(histogram) = &self.y_projection {
-                histogram.range
-            } else {
-                (0.0, 1.0)
-            };
             if ui.add_enabled(
                 self.add_y_projection,
                 egui::DragValue::new(&mut self.y_projection_line_1.x_value)
-                    .range(range.0..=range.1)
+                    .range(x_axis_settings.axis_range.0..=x_axis_settings.axis_range.1)
                     .speed(1.0)
                     .prefix("X1: "),
             ).changed() {
@@ -358,26 +611,33 @@ impl Projections {
                 self.add_y_projection,
                 egui::DragValue::new(&mut self.y_projection_line_2.x_value)
                     .speed(1.0)
-                    .range(range.0..=range.1)
+                    .range(x_axis_settings.axis_range.0..=x_axis_settings.axis_range.1)
                     .prefix("X2: "),
             ).changed() {
                 self.dragging = true;
             }
         });
 
+        if let Some((center, width)) = Self::projection_width_controls(
+            ui,
+            self.add_y_projection,
+            "Y Projection Span",
+            self.y_projection_center(),
+            self.y_projection_width(),
+            x_axis_settings,
+        ) {
+            self.set_y_projection_center_and_width(center, width, x_axis_settings.axis_range);
+            self.dragging = true;
+        }
+
         ui.horizontal(|ui| {
             ui.checkbox(&mut self.add_x_projection, "Add X Projection").on_hover_text("Keybinds:\nX = Add X Projection\nLeft click and drag the line at the center of the plot (cirlce)");
 
-            let range = if let Some(histogram) = &self.x_projection {
-                histogram.range
-            } else {
-                (0.0, 1.0)
-            };
             if ui.add_enabled(
                 self.add_x_projection,
                 egui::DragValue::new(&mut self.x_projection_line_1.y_value)
                     .speed(1.0)
-                    .range(range.0..=range.1)
+                    .range(y_axis_settings.axis_range.0..=y_axis_settings.axis_range.1)
                     .prefix("Y1: "),
             ).changed() {
                 self.dragging = true;
@@ -386,11 +646,23 @@ impl Projections {
                 self.add_x_projection,
                 egui::DragValue::new(&mut self.x_projection_line_2.y_value)
                     .speed(1.0)
-                    .range(range.0..=range.1)
+                    .range(y_axis_settings.axis_range.0..=y_axis_settings.axis_range.1)
                     .prefix("Y2: "),
             ).changed() {
                 self.dragging = true;
             }
         });
+
+        if let Some((center, width)) = Self::projection_width_controls(
+            ui,
+            self.add_x_projection,
+            "X Projection Span",
+            self.x_projection_center(),
+            self.x_projection_width(),
+            y_axis_settings,
+        ) {
+            self.set_x_projection_center_and_width(center, width, y_axis_settings.axis_range);
+            self.dragging = true;
+        }
     }
 }

--- a/src/histoer/histo2d/projections.rs
+++ b/src/histoer/histo2d/projections.rs
@@ -178,7 +178,9 @@ impl Projections {
     const DEFAULT_AXIS_OFFSET_FRACTION: f64 = 0.05;
     const CENTER_HANDLE_RADIUS: f32 = 6.0;
     const Y_CENTER_HANDLE_ID: &'static str = "Y Projection Center Handle";
+    const Y_CENTER_CONNECTOR_ID: &'static str = "Y Projection Center Connector";
     const X_CENTER_HANDLE_ID: &'static str = "X Projection Center Handle";
+    const X_CENTER_CONNECTOR_ID: &'static str = "X Projection Center Connector";
 
     pub fn new() -> Self {
         Self {
@@ -347,7 +349,8 @@ impl Projections {
         )
         .color(self.y_projection_line_1.color)
         .width(2.0)
-        .id(Id::new(Self::Y_CENTER_HANDLE_ID));
+        .allow_hover(false)
+        .id(Id::new(Self::Y_CENTER_CONNECTOR_ID));
         plot_ui.line(connector);
 
         let center_point = egui_plot::Points::new("", vec![[center_x, y_mid]])
@@ -369,7 +372,8 @@ impl Projections {
         )
         .color(self.x_projection_line_1.color)
         .width(2.0)
-        .id(Id::new(Self::X_CENTER_HANDLE_ID));
+        .allow_hover(false)
+        .id(Id::new(Self::X_CENTER_CONNECTOR_ID));
         plot_ui.line(connector);
 
         let center_point = egui_plot::Points::new("", vec![[x_mid, center_y]])
@@ -457,12 +461,18 @@ impl Projections {
                 .interactive_dragging(plot_response, None);
             self.y_projection_line_2
                 .interactive_dragging(plot_response, None);
+            if self.y_projection_line_1.is_dragging || self.y_projection_line_2.is_dragging {
+                self.y_center_dragging = false;
+            }
             self.interactive_drag_y_projection_center(plot_response);
         }
 
         if self.add_x_projection {
             self.x_projection_line_1.interactive_dragging(plot_response);
             self.x_projection_line_2.interactive_dragging(plot_response);
+            if self.x_projection_line_1.is_dragging || self.x_projection_line_2.is_dragging {
+                self.x_center_dragging = false;
+            }
             self.interactive_drag_x_projection_center(plot_response);
         }
     }

--- a/src/histoer/histo2d/projections.rs
+++ b/src/histoer/histo2d/projections.rs
@@ -44,6 +44,12 @@ impl Histogram2D {
 
     pub fn check_projections(&mut self) {
         if self.plot_settings.projections.add_y_projection {
+            if self.plot_settings.projections.y_projection.is_none() {
+                self.plot_settings
+                    .projections
+                    .initialize_y_projection_lines((self.range.x.min, self.range.x.max));
+            }
+
             let x1 = self.plot_settings.projections.y_projection_line_1.x_value;
             let x2 = self.plot_settings.projections.y_projection_line_2.x_value;
             let (min_x, max_x) = if x1 < x2 { (x1, x2) } else { (x2, x1) };
@@ -74,9 +80,6 @@ impl Histogram2D {
 
                 self.plot_settings.projections.y_projection = Some(y_histogram);
 
-                self.plot_settings.projections.y_projection_line_1.x_value = self.range.x.min;
-                self.plot_settings.projections.y_projection_line_2.x_value = self.range.x.max;
-
                 if let Some(y_projection) = self.plot_settings.projections.y_projection.as_mut() {
                     y_projection.plot_settings.egui_settings.reset_axis = true;
                 }
@@ -91,6 +94,12 @@ impl Histogram2D {
         }
 
         if self.plot_settings.projections.add_x_projection {
+            if self.plot_settings.projections.x_projection.is_none() {
+                self.plot_settings
+                    .projections
+                    .initialize_x_projection_lines((self.range.y.min, self.range.y.max));
+            }
+
             let y1 = self.plot_settings.projections.x_projection_line_1.y_value;
             let y2 = self.plot_settings.projections.x_projection_line_2.y_value;
             let (min_y, max_y) = if y1 < y2 { (y1, y2) } else { (y2, y1) };
@@ -120,9 +129,6 @@ impl Histogram2D {
                 x_histogram.line.color = egui::Color32::from_rgb(0, 0, 255);
 
                 self.plot_settings.projections.x_projection = Some(x_histogram);
-
-                self.plot_settings.projections.x_projection_line_1.y_value = self.range.y.min;
-                self.plot_settings.projections.x_projection_line_2.y_value = self.range.y.max;
 
                 if let Some(x_projection) = self.plot_settings.projections.x_projection.as_mut() {
                     x_projection.plot_settings.egui_settings.reset_axis = true;
@@ -154,8 +160,12 @@ pub struct Projections {
     pub fill_x_line: EguiLine,
 
     pub dragging: bool,
+    #[serde(skip)]
+    pub current_plot_bounds: Option<((f64, f64), (f64, f64))>,
 }
 impl Projections {
+    const DEFAULT_AXIS_OFFSET_FRACTION: f64 = 0.05;
+
     pub fn new() -> Self {
         Self {
             add_y_projection: false,
@@ -208,7 +218,39 @@ impl Projections {
                 ..EguiLine::default()
             },
             dragging: false,
+            current_plot_bounds: None,
         }
+    }
+
+    fn axis_offset(min: f64, max: f64) -> f64 {
+        let width = (max - min).abs();
+        if width > 0.0 {
+            width * Self::DEFAULT_AXIS_OFFSET_FRACTION
+        } else {
+            0.0
+        }
+    }
+
+    pub fn initialize_y_projection_lines(&mut self, fallback_x_range: (f64, f64)) {
+        let (x_min, x_max) = self
+            .current_plot_bounds
+            .map(|(x_range, _)| x_range)
+            .unwrap_or(fallback_x_range);
+        let offset = Self::axis_offset(x_min, x_max);
+
+        self.y_projection_line_1.x_value = x_min + offset;
+        self.y_projection_line_2.x_value = x_max - offset;
+    }
+
+    pub fn initialize_x_projection_lines(&mut self, fallback_y_range: (f64, f64)) {
+        let (y_min, y_max) = self
+            .current_plot_bounds
+            .map(|(_, y_range)| y_range)
+            .unwrap_or(fallback_y_range);
+        let offset = Self::axis_offset(y_min, y_max);
+
+        self.x_projection_line_1.y_value = y_min + offset;
+        self.x_projection_line_2.y_value = y_max - offset;
     }
 
     fn show_y_projection(&mut self, ui: &egui::Ui) {

--- a/src/histoer/histo2d/projections.rs
+++ b/src/histoer/histo2d/projections.rs
@@ -337,6 +337,31 @@ impl Projections {
         }
     }
 
+    fn drag_step(axis_settings: ProjectionAxisSettings) -> f64 {
+        let axis_span = (axis_settings.axis_range.1 - axis_settings.axis_range.0).abs();
+        let fallback_step = if axis_span > 0.0 {
+            axis_span / 100.0
+        } else {
+            0.1
+        };
+
+        let step = if axis_settings.bin_width > 0.0 {
+            axis_settings.bin_width.min(fallback_step)
+        } else {
+            fallback_step
+        };
+
+        step.max(0.0001)
+    }
+
+    fn drag_decimals(step: f64) -> usize {
+        if step >= 1.0 {
+            0
+        } else {
+            (-step.log10()).ceil().clamp(0.0, 6.0) as usize
+        }
+    }
+
     fn show_y_projection(&mut self, ui: &egui::Ui) {
         if self.add_y_projection && self.y_projection.is_some() {
             let name = if let Some(histogram) = &self.y_projection {
@@ -534,6 +559,8 @@ impl Projections {
         let mut next_width = width;
         let mut width_bins = Self::projection_bins(width, axis_settings.bin_width);
         let mut changed = false;
+        let drag_step = Self::drag_step(axis_settings);
+        let drag_decimals = Self::drag_decimals(drag_step);
 
         ui.vertical(|ui| {
             ui.label(label);
@@ -557,7 +584,9 @@ impl Projections {
                                 0.0..=((axis_settings.axis_range.1 - axis_settings.axis_range.0)
                                     .abs()),
                             )
-                            .speed(axis_settings.bin_width.max(0.1))
+                            .speed(drag_step)
+                            .min_decimals(drag_decimals)
+                            .max_decimals(drag_decimals)
                             .prefix("range: "),
                     )
                     .changed();
@@ -585,6 +614,10 @@ impl Projections {
         y_axis_settings: ProjectionAxisSettings,
     ) {
         ui.heading("Projections");
+        let x_drag_step = Self::drag_step(x_axis_settings);
+        let x_drag_decimals = Self::drag_decimals(x_drag_step);
+        let y_drag_step = Self::drag_step(y_axis_settings);
+        let y_drag_decimals = Self::drag_decimals(y_drag_step);
 
         ui.horizontal(|ui| {
             ui.checkbox(&mut self.add_y_projection, "Add Y Projection").on_hover_text("Keybinds:\nY = Add Y Projection\nLeft click and drag the line at the center of the plot (cirlce)");
@@ -593,7 +626,9 @@ impl Projections {
                 self.add_y_projection,
                 egui::DragValue::new(&mut self.y_projection_line_1.x_value)
                     .range(x_axis_settings.axis_range.0..=x_axis_settings.axis_range.1)
-                    .speed(1.0)
+                    .speed(x_drag_step)
+                    .min_decimals(x_drag_decimals)
+                    .max_decimals(x_drag_decimals)
                     .prefix("X1: "),
             ).changed() {
                 self.dragging = true;
@@ -602,7 +637,9 @@ impl Projections {
             if ui.add_enabled(
                 self.add_y_projection,
                 egui::DragValue::new(&mut self.y_projection_line_2.x_value)
-                    .speed(1.0)
+                    .speed(x_drag_step)
+                    .min_decimals(x_drag_decimals)
+                    .max_decimals(x_drag_decimals)
                     .range(x_axis_settings.axis_range.0..=x_axis_settings.axis_range.1)
                     .prefix("X2: "),
             ).changed() {
@@ -628,7 +665,9 @@ impl Projections {
             if ui.add_enabled(
                 self.add_x_projection,
                 egui::DragValue::new(&mut self.x_projection_line_1.y_value)
-                    .speed(1.0)
+                    .speed(y_drag_step)
+                    .min_decimals(y_drag_decimals)
+                    .max_decimals(y_drag_decimals)
                     .range(y_axis_settings.axis_range.0..=y_axis_settings.axis_range.1)
                     .prefix("Y1: "),
             ).changed() {
@@ -637,7 +676,9 @@ impl Projections {
             if ui.add_enabled(
                 self.add_x_projection,
                 egui::DragValue::new(&mut self.x_projection_line_2.y_value)
-                    .speed(1.0)
+                    .speed(y_drag_step)
+                    .min_decimals(y_drag_decimals)
+                    .max_decimals(y_drag_decimals)
                     .range(y_axis_settings.axis_range.0..=y_axis_settings.axis_range.1)
                     .prefix("Y2: "),
             ).changed() {


### PR DESCRIPTION
### Motivation
- New projections (X/Y) should start near the current visible axes instead of snapping to the full histogram extent so the midpoint drag handle is easier to grab after pressing `X`/`Y`.
- Use a small inset from the axis edges so users can immediately interact with the projection handles without having to chase the exact edge coordinates.

### Description
- Cache the active plot bounds during drawing by setting `projections.current_plot_bounds` inside `Histogram2D::draw` from `plot_ui.plot_bounds()` so initial projection placement respects the current zoom/pan.
- Add `current_plot_bounds: Option<((f64, f64), (f64, f64))>` to `Projections` and a `const DEFAULT_AXIS_OFFSET_FRACTION: f64 = 0.05` to control the inset fraction.
- Implement `axis_offset`, `initialize_y_projection_lines`, and `initialize_x_projection_lines` in `Projections` to compute and apply a small inset from the visible bounds when creating new projections.
- Use these initializers from `check_projections` when a fresh X/Y projection is created (and remove the previous behavior that always set handles to the full histogram range).

### Testing
- Ran `cargo fmt --check`, which completed successfully.
- Started `cargo check`; the workspace dependency build was in progress when this change was finished (compilation was initiated but not fully finished in this environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c151103f788327bd194d865a58c669)