### PR TITLE
Add Modify action for stored fits and persist lmfit marker metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ The 1D histogram interface in **Spectrix** is designed for fast, interactive pea
 - Choose and tune background models: linear, quadratic, power law, exponential.
 - Rebin and restyle plots from the context menu.
 - Store fit results and review them in a dedicated side panel.
+- Click **Modify** on a stored fit to move it back into the temp fit editor with its saved markers/settings.
+- Click **Refit** in the Fit Panel header to re-run all stored fits on the latest incoming data.
 - Use keyboard-driven controls for quick analysis loops.
 
 ### Fitting Engine
@@ -321,6 +323,18 @@ This metadata is also written into the underlying lmfit `ModelResult` payload:
 - assigned energy and uncertainty (`g{i}_energy`, `g{i}_energy_uncertainty`)
 - calibrated Gaussian parameters, including `g{i}_center_calibrated`, `g{i}_sigma_calibrated`, `g{i}_fwhm_calibrated`, plus calibrated copies for area/amplitude/height
 - calibration constants and uncertainties, including `calibration_a`, `calibration_b`, `calibration_c`, and `calibration_a_uncertainty`, `calibration_b_uncertainty`, `calibration_c_uncertainty`
+ - fit marker metadata for Python interoperability:
+  - `region_marker_count`, `region_marker_0`, `region_marker_1`, ...
+  - `peak_marker_count`, `peak_marker_0`, `peak_marker_1`, ...
+  - `bg_marker_count`, `bg_marker_start_0`, `bg_marker_end_0`, ...
+  - fit/background flags: `bg_model_type`, `fit_equal_sigma`, `fit_free_position`
+
+Stored-fit modify/refit behavior:
+
+- **Modify** removes the selected fit from the stored list, restores its marker/background settings, and moves it into the temp-fit slot for editing.
+- On refit, Spectrix preserves existing UUID and assigned-energy values by remapping prior assignments onto the new fitted peak means.
+- If background model is `None`, no background markers are restored/generated.
+
 
 Because of that, exported lmfit `.sav` files include both fit parameters and calibration/UUID context, so they can be loaded and further analyzed directly in Python (for example with `lmfit.model.load_modelresult`).
 

--- a/src/fitter/fit_handler.rs
+++ b/src/fitter/fit_handler.rs
@@ -47,6 +47,8 @@ pub struct Fits {
     pub sort_state: SortState,
     #[serde(skip)]
     pub pending_modify_fit: Option<usize>,
+    #[serde(skip)]
+    pub pending_refit_all: bool,
 }
 
 impl Default for Fits {
@@ -67,11 +69,16 @@ impl Fits {
                 asc: true,
             },
             pending_modify_fit: None,
+            pending_refit_all: false,
         }
     }
 
     pub fn take_pending_modify_fit(&mut self) -> Option<usize> {
         self.pending_modify_fit.take()
+    }
+
+    pub fn take_pending_refit_all(&mut self) -> bool {
+        std::mem::take(&mut self.pending_refit_all)
     }
 
     pub fn store_temp_fit(&mut self) {
@@ -875,6 +882,15 @@ impl Fits {
                 .show(ui, |ui| {
                     ui.vertical(|ui| {
                         ui.heading("Fit Panel");
+                        if ui
+                            .button("Refit")
+                            .on_hover_text(
+                                "Re-run each stored fit on current data by loading it into temp, fitting, then storing it again.",
+                            )
+                            .clicked()
+                        {
+                            self.pending_refit_all = true;
+                        }
                         self.save_and_load_ui(ui);
 
                         self.settings.ui(ui);

--- a/src/fitter/fit_handler.rs
+++ b/src/fitter/fit_handler.rs
@@ -881,16 +881,19 @@ impl Fits {
                 .id_salt("Context menu fit stats grid")
                 .show(ui, |ui| {
                     ui.vertical(|ui| {
-                        ui.heading("Fit Panel");
-                        if ui
-                            .button("Refit")
-                            .on_hover_text(
-                                "Re-run each stored fit on current data by loading it into temp, fitting, then storing it again.",
-                            )
-                            .clicked()
-                        {
-                            self.pending_refit_all = true;
-                        }
+                        ui.horizontal(|ui| {
+                            ui.heading("Fit Panel");
+                            if !self.stored_fits.is_empty()
+                                && ui
+                                    .button("Refit")
+                                    .on_hover_text(
+                                        "Re-run each stored fit on current data by loading it into temp, fitting, then storing it again.",
+                                    )
+                                    .clicked()
+                            {
+                                self.pending_refit_all = true;
+                            }
+                        });
                         self.save_and_load_ui(ui);
 
                         self.settings.ui(ui);

--- a/src/fitter/fit_handler.rs
+++ b/src/fitter/fit_handler.rs
@@ -45,6 +45,8 @@ pub struct Fits {
     pub settings: FitSettings,
     pub calibration: Calibration,
     pub sort_state: SortState,
+    #[serde(skip)]
+    pub pending_modify_fit: Option<usize>,
 }
 
 impl Default for Fits {
@@ -64,7 +66,12 @@ impl Fits {
                 col: SortCol::Fit,
                 asc: true,
             },
+            pending_modify_fit: None,
         }
+    }
+
+    pub fn take_pending_modify_fit(&mut self) -> Option<usize> {
+        self.pending_modify_fit.take()
     }
 
     pub fn store_temp_fit(&mut self) {
@@ -548,6 +555,7 @@ impl Fits {
 
         // NEW: stash a pending deletion
         let mut to_remove: Option<usize> = None;
+        let mut to_modify: Option<usize> = None;
 
         // NEW: sorting key helper
         let key = |r: &Row, col: SortCol| -> f64 {
@@ -708,6 +716,9 @@ impl Fits {
                                         log::info!("Saved lmfit result to {path:?}");
                                     }
                                 }
+                                if ui.button("Modify").clicked() {
+                                    to_modify = Some(i);
+                                }
                                 ui.menu_button("Fit Report", |ui| {
                                     egui::ScrollArea::vertical().show(ui, |ui| {
                                         ui.horizontal_wrapped(|ui| {
@@ -815,6 +826,8 @@ impl Fits {
         {
             self.stored_fits.remove(i);
         }
+
+        self.pending_modify_fit = to_modify;
     }
 
     pub fn fit_stats_ui(&mut self, ui: &mut egui::Ui) {

--- a/src/fitter/fit_handler.rs
+++ b/src/fitter/fit_handler.rs
@@ -402,11 +402,15 @@ impl Fits {
             None
         };
 
+        let calibrated = self.settings.calibrated;
         if let Some(temp_fit) = &self.temp_fit {
             temp_fit.draw(plot_ui, calibration);
+
+            if let Some(FitResult::Gaussian(gauss)) = &temp_fit.fit_result {
+                gauss.draw_uuid(plot_ui, calibrated);
+            }
         }
 
-        let calibrated = self.settings.calibrated;
         for fit in &mut self.stored_fits.iter() {
             fit.draw(plot_ui, calibration);
 

--- a/src/fitter/main_fitter.rs
+++ b/src/fitter/main_fitter.rs
@@ -63,6 +63,19 @@ impl BackgroundResult {
     }
 }
 
+impl BackgroundModel {
+    pub fn type_name(&self) -> String {
+        match self {
+            Self::Linear(_) => "linear",
+            Self::Quadratic(_) => "quadratic",
+            Self::PowerLaw(_) => "powerlaw",
+            Self::Exponential(_) => "exponential",
+            Self::None => "None",
+        }
+        .to_owned()
+    }
+}
+
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct Fitter {
     pub name: String,

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -361,8 +361,8 @@ impl GaussianFitter {
         let region_markers = if self.region_markers.len() >= 2 {
             self.region_markers.clone()
         } else if let (Some(min), Some(max)) = (
-            self.data.x.iter().cloned().reduce(f64::min),
-            self.data.x.iter().cloned().reduce(f64::max),
+            self.data.x.iter().copied().reduce(f64::max),
+            self.data.x.iter().copied().reduce(f64::min),
         ) {
             vec![min, max]
         } else {

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -1346,25 +1346,24 @@ def load_result(filename: str):
                 metadata_found,
             )) = fit_metadata
             {
+                let fitted_peak_markers = self.peak_markers.clone();
                 self.region_markers = region_markers.clone();
-                self.peak_markers = if peak_markers.is_empty() {
-                    self.fit_result
-                        .iter()
-                        .filter_map(|p| p.mean.value)
-                        .collect::<Vec<_>>()
-                } else {
-                    peak_markers.clone()
-                };
                 self.background_markers = background_markers.clone();
                 self.fit_settings.equal_stdev = equal_stdev;
                 self.fit_settings.free_position = free_position;
 
                 self.fit_metadata = Some(GaussianFitMetadata {
                     region_markers,
-                    peak_markers: self.peak_markers.clone(),
+                    peak_markers: if peak_markers.is_empty() {
+                        fitted_peak_markers.clone()
+                    } else {
+                        peak_markers
+                    },
                     background_markers,
                     background_model,
                 });
+
+                self.peak_markers = fitted_peak_markers;
 
                 if !metadata_found {
                     log::warn!(

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -474,25 +474,6 @@ def _code_to_bg_type(code: float) -> str:
 
 def _inject_spectrix_metadata(result, region_markers, peak_markers, background_markers, bg_type, equal_sigma, free_position):
     params = result.params
-    params.add('spectrix_meta_version', value=1, vary=False)
-
-    params.add('spectrix_meta_region_count', value=len(region_markers), vary=False)
-    for i, val in enumerate(region_markers):
-        params.add(f'spectrix_meta_region_{i}', value=float(val), vary=False)
-
-    params.add('spectrix_meta_peak_count', value=len(peak_markers), vary=False)
-    for i, val in enumerate(peak_markers):
-        params.add(f'spectrix_meta_peak_{i}', value=float(val), vary=False)
-
-    params.add('spectrix_meta_bg_pair_count', value=len(background_markers), vary=False)
-    for i, (start, end) in enumerate(background_markers):
-        params.add(f'spectrix_meta_bg_start_{i}', value=float(start), vary=False)
-        params.add(f'spectrix_meta_bg_end_{i}', value=float(end), vary=False)
-
-    params.add('spectrix_meta_bg_type', value=float(_bg_type_to_code(bg_type)), vary=False)
-    params.add('spectrix_meta_equal_sigma', value=1.0 if equal_sigma else 0.0, vary=False)
-    params.add('spectrix_meta_free_position', value=1.0 if free_position else 0.0, vary=False)
-
     # Python-friendly marker parameter names for external tools/scripts
     params.add('region_marker_count', value=len(region_markers), vary=False)
     for i, val in enumerate(region_markers):

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -525,6 +525,58 @@ def _extract_spectrix_metadata(result):
         True,
     )
 
+def _append_spectrix_marker_block(fit_report, region_markers, peak_markers, background_markers):
+    lines = [
+        '',
+        '--- SPECTRIX_MARKERS_START ---',
+        'region_markers=' + ','.join(str(float(x)) for x in region_markers),
+        'peak_markers=' + ','.join(str(float(x)) for x in peak_markers),
+        'background_markers=' + ';'.join(f'{float(s)}:{float(e)}' for s, e in background_markers),
+        '--- SPECTRIX_MARKERS_END ---',
+    ]
+    return fit_report + '\\n' + '\\n'.join(lines)
+
+def _extract_spectrix_marker_block(fit_report):
+    start_tag = '--- SPECTRIX_MARKERS_START ---'
+    end_tag = '--- SPECTRIX_MARKERS_END ---'
+    if start_tag not in fit_report or end_tag not in fit_report:
+        return None
+
+    start_idx = fit_report.index(start_tag) + len(start_tag)
+    end_idx = fit_report.index(end_tag, start_idx)
+    block = fit_report[start_idx:end_idx]
+
+    values = {}
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line or '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        values[key.strip()] = value.strip()
+
+    def _parse_float_list(text):
+        if not text:
+            return []
+        return [float(x) for x in text.split(',') if x.strip()]
+
+    def _parse_bg_pairs(text):
+        if not text:
+            return []
+        out = []
+        for entry in text.split(';'):
+            entry = entry.strip()
+            if not entry or ':' not in entry:
+                continue
+            s, e = entry.split(':', 1)
+            out.append((float(s), float(e)))
+        return out
+
+    return (
+        _parse_float_list(values.get('region_markers', '')),
+        _parse_float_list(values.get('peak_markers', '')),
+        _parse_bg_pairs(values.get('background_markers', '')),
+    )
+
 def GaussianFit(counts: list, centers: list,
                 region_markers: list, peak_markers: list = [], background_markers: list = [],
                 equal_sigma: bool = True, free_position: bool = True,                 
@@ -798,6 +850,7 @@ def GaussianFit(counts: list, centers: list,
     print('Fit Report:')
 
     fit_report = result.fit_report()
+    fit_report = _append_spectrix_marker_block(fit_report, region_markers, peak_markers, background_markers)
     print(fit_report)
 
     # Extract Gaussian and background parameters
@@ -940,12 +993,31 @@ def load_result(filename: str):
 
     fit_metadata = _extract_spectrix_metadata(result)
     if fit_metadata is None:
+        marker_block = _extract_spectrix_marker_block(fit_report)
+        if marker_block is not None:
+            region_m, peak_m, background_m = marker_block
+            fit_metadata = (
+                region_m,
+                peak_m,
+                background_m,
+                'None',
+                True,
+                True,
+                False,
+            )
+
+    if fit_metadata is None:
         if len(centers := result.userkws['x']) > 1:
             bin_width = float(centers[1] - centers[0])
         else:
             bin_width = 1.0
-        fallback_region = [float(x_min), float(x_max)]
-        fallback_peak_markers = [float(p) for p in peak_markers]
+
+        fitted_means = [float(g[2]) for g in gaussian_params]
+        if len(fitted_means) >= 2:
+            fallback_region = [min(fitted_means), max(fitted_means)]
+        else:
+            fallback_region = [float(x_min), float(x_max)]
+        fallback_peak_markers = fitted_means if fitted_means else [float(p) for p in peak_markers]
         fallback_background = [
             (fallback_region[0] - bin_width, fallback_region[0]),
             (fallback_region[1], fallback_region[1] + bin_width),

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -584,58 +584,6 @@ def _extract_spectrix_metadata(result):
         True,
     )
 
-def _append_spectrix_marker_block(fit_report, region_markers, peak_markers, background_markers):
-    lines = [
-        '',
-        '--- SPECTRIX_MARKERS_START ---',
-        'region_markers=' + ','.join(str(float(x)) for x in region_markers),
-        'peak_markers=' + ','.join(str(float(x)) for x in peak_markers),
-        'background_markers=' + ';'.join(f'{float(s)}:{float(e)}' for s, e in background_markers),
-        '--- SPECTRIX_MARKERS_END ---',
-    ]
-    return fit_report + '\\n' + '\\n'.join(lines)
-
-def _extract_spectrix_marker_block(fit_report):
-    start_tag = '--- SPECTRIX_MARKERS_START ---'
-    end_tag = '--- SPECTRIX_MARKERS_END ---'
-    if start_tag not in fit_report or end_tag not in fit_report:
-        return None
-
-    start_idx = fit_report.index(start_tag) + len(start_tag)
-    end_idx = fit_report.index(end_tag, start_idx)
-    block = fit_report[start_idx:end_idx]
-
-    values = {}
-    for raw_line in block.splitlines():
-        line = raw_line.strip()
-        if not line or '=' not in line:
-            continue
-        key, value = line.split('=', 1)
-        values[key.strip()] = value.strip()
-
-    def _parse_float_list(text):
-        if not text:
-            return []
-        return [float(x) for x in text.split(',') if x.strip()]
-
-    def _parse_bg_pairs(text):
-        if not text:
-            return []
-        out = []
-        for entry in text.split(';'):
-            entry = entry.strip()
-            if not entry or ':' not in entry:
-                continue
-            s, e = entry.split(':', 1)
-            out.append((float(s), float(e)))
-        return out
-
-    return (
-        _parse_float_list(values.get('region_markers', '')),
-        _parse_float_list(values.get('peak_markers', '')),
-        _parse_bg_pairs(values.get('background_markers', '')),
-    )
-
 def GaussianFit(counts: list, centers: list,
                 region_markers: list, peak_markers: list = [], background_markers: list = [],
                 equal_sigma: bool = True, free_position: bool = True,                 
@@ -909,7 +857,6 @@ def GaussianFit(counts: list, centers: list,
     print('Fit Report:')
 
     fit_report = result.fit_report()
-    fit_report = _append_spectrix_marker_block(fit_report, region_markers, peak_markers, background_markers)
     print(fit_report)
 
     # Extract Gaussian and background parameters
@@ -1051,20 +998,6 @@ def load_result(filename: str):
         y_data_line = result.eval(x=x_data_line)
 
     fit_metadata = _extract_spectrix_metadata(result)
-    if fit_metadata is None:
-        marker_block = _extract_spectrix_marker_block(fit_report)
-        if marker_block is not None:
-            region_m, peak_m, background_m = marker_block
-            fit_metadata = (
-                region_m,
-                peak_m,
-                background_m,
-                'None',
-                True,
-                True,
-                False,
-            )
-
     if fit_metadata is None:
         if len(centers := result.userkws['x']) > 1:
             bin_width = float(centers[1] - centers[0])

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -296,6 +296,14 @@ pub struct GaussianFitSettings {
 }
 
 #[derive(Default, Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct GaussianFitMetadata {
+    pub region_markers: Vec<f64>,
+    pub peak_markers: Vec<f64>,
+    pub background_markers: Vec<(f64, f64)>,
+    pub background_model: String,
+}
+
+#[derive(Default, Clone, Debug, serde::Deserialize, serde::Serialize)]
 pub struct GaussianFitter {
     pub data: Data,
     pub region_markers: Vec<f64>,
@@ -309,6 +317,7 @@ pub struct GaussianFitter {
     pub fit_report: String,
     pub lmfit_result: Option<String>,
     pub sigma_bounds: Option<(Vec<f64>, Vec<f64>)>, // (mins_x, maxs_x)
+    pub fit_metadata: Option<GaussianFitMetadata>,
 }
 
 impl GaussianFitter {
@@ -340,7 +349,44 @@ impl GaussianFitter {
             fit_report: String::new(),
             lmfit_result: None,
             sigma_bounds: None,
+            fit_metadata: None,
         }
+    }
+
+    pub fn fit_metadata_with_fallback(&self) -> (GaussianFitMetadata, bool) {
+        if let Some(metadata) = &self.fit_metadata {
+            return (metadata.clone(), true);
+        }
+
+        let region_markers = if self.region_markers.len() >= 2 {
+            self.region_markers.clone()
+        } else if let (Some(min), Some(max)) = (
+            self.data.x.iter().cloned().reduce(f64::min),
+            self.data.x.iter().cloned().reduce(f64::max),
+        ) {
+            vec![min, max]
+        } else {
+            Vec::new()
+        };
+
+        let peak_markers = if !self.peak_markers.is_empty() {
+            self.peak_markers.clone()
+        } else {
+            self.fit_result
+                .iter()
+                .filter_map(|p| p.mean.value)
+                .collect::<Vec<_>>()
+        };
+
+        (
+            GaussianFitMetadata {
+                region_markers,
+                peak_markers,
+                background_markers: self.background_markers.clone(),
+                background_model: self.background_model.type_name(),
+            },
+            false,
+        )
     }
 
     pub fn get_calibration_data(&self) -> Vec<(f64, f64, f64, f64)> {
@@ -417,6 +463,67 @@ impl GaussianFitter {
 import numpy as np
 import lmfit
 from lmfit.model import load_modelresult, save_modelresult
+
+def _bg_type_to_code(bg_type: str) -> int:
+    mapping = {'None': 0, 'linear': 1, 'quadratic': 2, 'exponential': 3, 'powerlaw': 4}
+    return mapping.get(bg_type, 0)
+
+def _code_to_bg_type(code: float) -> str:
+    mapping = {0: 'None', 1: 'linear', 2: 'quadratic', 3: 'exponential', 4: 'powerlaw'}
+    return mapping.get(int(code), 'None')
+
+def _inject_spectrix_metadata(result, region_markers, peak_markers, background_markers, bg_type, equal_sigma, free_position):
+    params = result.params
+    params.add('spectrix_meta_version', value=1, vary=False)
+
+    params.add('spectrix_meta_region_count', value=len(region_markers), vary=False)
+    for i, val in enumerate(region_markers):
+        params.add(f'spectrix_meta_region_{i}', value=float(val), vary=False)
+
+    params.add('spectrix_meta_peak_count', value=len(peak_markers), vary=False)
+    for i, val in enumerate(peak_markers):
+        params.add(f'spectrix_meta_peak_{i}', value=float(val), vary=False)
+
+    params.add('spectrix_meta_bg_pair_count', value=len(background_markers), vary=False)
+    for i, (start, end) in enumerate(background_markers):
+        params.add(f'spectrix_meta_bg_start_{i}', value=float(start), vary=False)
+        params.add(f'spectrix_meta_bg_end_{i}', value=float(end), vary=False)
+
+    params.add('spectrix_meta_bg_type', value=float(_bg_type_to_code(bg_type)), vary=False)
+    params.add('spectrix_meta_equal_sigma', value=1.0 if equal_sigma else 0.0, vary=False)
+    params.add('spectrix_meta_free_position', value=1.0 if free_position else 0.0, vary=False)
+
+def _extract_spectrix_metadata(result):
+    params = result.params
+    if 'spectrix_meta_version' not in params:
+        return None
+
+    region_count = int(params['spectrix_meta_region_count'].value) if 'spectrix_meta_region_count' in params else 0
+    peak_count = int(params['spectrix_meta_peak_count'].value) if 'spectrix_meta_peak_count' in params else 0
+    bg_pair_count = int(params['spectrix_meta_bg_pair_count'].value) if 'spectrix_meta_bg_pair_count' in params else 0
+
+    region_markers = [float(params[f'spectrix_meta_region_{i}'].value) for i in range(region_count)]
+    peak_markers = [float(params[f'spectrix_meta_peak_{i}'].value) for i in range(peak_count)]
+
+    background_markers = []
+    for i in range(bg_pair_count):
+        start = float(params[f'spectrix_meta_bg_start_{i}'].value)
+        end = float(params[f'spectrix_meta_bg_end_{i}'].value)
+        background_markers.append((start, end))
+
+    bg_type_code = float(params['spectrix_meta_bg_type'].value) if 'spectrix_meta_bg_type' in params else 0.0
+    equal_sigma = (float(params['spectrix_meta_equal_sigma'].value) > 0.5) if 'spectrix_meta_equal_sigma' in params else True
+    free_position = (float(params['spectrix_meta_free_position'].value) > 0.5) if 'spectrix_meta_free_position' in params else True
+
+    return (
+        region_markers,
+        peak_markers,
+        background_markers,
+        _code_to_bg_type(bg_type_code),
+        equal_sigma,
+        free_position,
+        True,
+    )
 
 def GaussianFit(counts: list, centers: list,
                 region_markers: list, peak_markers: list = [], background_markers: list = [],
@@ -735,10 +842,21 @@ def GaussianFit(counts: list, centers: list,
         x_data_line = np.linspace(x_data[0], x_data[-1], 5 * len(x_data))
         y_data_line = result.eval(x=x_data_line)
 
+    fit_metadata = (
+        list(region_markers),
+        list(peak_markers),
+        list(background_markers),
+        bg_type,
+        equal_sigma,
+        free_position,
+        True,
+    )
+    _inject_spectrix_metadata(result, region_markers, peak_markers, background_markers, bg_type, equal_sigma, free_position)
+
     # save the fit result to a temp file
     save_modelresult(result, 'temp_fit.sav')
 
-    return gaussian_params, background_params, x_data_line, y_data_line, fit_report, additional_params, result
+    return gaussian_params, background_params, x_data_line, y_data_line, fit_report, additional_params, fit_metadata, result
 
 def load_result(filename: str):
     result = load_modelresult(filename)
@@ -820,10 +938,32 @@ def load_result(filename: str):
         x_data_line = np.linspace(x_data[0], x_data[-1], 5 * len(x_data))
         y_data_line = result.eval(x=x_data_line)
 
+    fit_metadata = _extract_spectrix_metadata(result)
+    if fit_metadata is None:
+        if len(centers := result.userkws['x']) > 1:
+            bin_width = float(centers[1] - centers[0])
+        else:
+            bin_width = 1.0
+        fallback_region = [float(x_min), float(x_max)]
+        fallback_peak_markers = [float(p) for p in peak_markers]
+        fallback_background = [
+            (fallback_region[0] - bin_width, fallback_region[0]),
+            (fallback_region[1], fallback_region[1] + bin_width),
+        ]
+        fit_metadata = (
+            fallback_region,
+            fallback_peak_markers,
+            fallback_background,
+            'None',
+            True,
+            True,
+            False,
+        )
+
     # save the fit result to a temp file
     save_modelresult(result, 'temp_fit.sav')
 
-    return gaussian_params, background_params, x_data_line, y_data_line, fit_report, additional_params
+    return gaussian_params, background_params, x_data_line, y_data_line, fit_report, additional_params, fit_metadata
 
 ");
 
@@ -1127,6 +1267,18 @@ def load_result(filename: str):
             let y_composition = result.get_item(3)?.extract::<Vec<f64>>()?;
             let fit_report = result.get_item(4)?.extract::<String>()?;
             let additional_params = result.get_item(5)?.extract::<Vec<(f64, f64)>>()?;
+            let fit_metadata = result.get_item(6).ok().and_then(|item| {
+                item.extract::<(
+                    Vec<f64>,
+                    Vec<f64>,
+                    Vec<(f64, f64)>,
+                    String,
+                    bool,
+                    bool,
+                    bool,
+                )>()
+                .ok()
+            });
 
             // get the temp fit result, store the text in the struct
             let fit_text = std::fs::read_to_string("temp_fit.sav")
@@ -1182,6 +1334,49 @@ def load_result(filename: str):
                 gaussian_param.generate_fit_points(100);
 
                 self.fit_result.push(gaussian_param);
+            }
+
+            if let Some((
+                region_markers,
+                peak_markers,
+                background_markers,
+                background_model,
+                equal_stdev,
+                free_position,
+                metadata_found,
+            )) = fit_metadata
+            {
+                self.region_markers = region_markers.clone();
+                self.peak_markers = if peak_markers.is_empty() {
+                    self.fit_result
+                        .iter()
+                        .filter_map(|p| p.mean.value)
+                        .collect::<Vec<_>>()
+                } else {
+                    peak_markers.clone()
+                };
+                self.background_markers = background_markers.clone();
+                self.fit_settings.equal_stdev = equal_stdev;
+                self.fit_settings.free_position = free_position;
+
+                self.fit_metadata = Some(GaussianFitMetadata {
+                    region_markers,
+                    peak_markers: self.peak_markers.clone(),
+                    background_markers,
+                    background_model,
+                });
+
+                if !metadata_found {
+                    log::warn!(
+                        "No SpectriX fit metadata found in lmfit result; generated fallback metadata from existing Gaussian parameters."
+                    );
+                }
+            } else {
+                let (metadata, _) = self.fit_metadata_with_fallback();
+                self.fit_metadata = Some(metadata);
+                log::warn!(
+                    "Unable to read fit metadata from lmfit result; generated fallback metadata from Gaussian fit."
+                );
             }
 
             if self.background_result.is_none() && !background_params.is_empty() {

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -848,6 +848,7 @@ def GaussianFit(counts: list, centers: list,
 
     # Fit the model to the data
     result = model.fit(y_data, params, x=x_data)
+    _inject_spectrix_metadata(result, region_markers, peak_markers, background_markers, bg_type, equal_sigma, free_position)
 
     # Print initial parameter guesses
     print('Initial Parameter Guesses:')
@@ -910,7 +911,6 @@ def GaussianFit(counts: list, centers: list,
         free_position,
         True,
     )
-    _inject_spectrix_metadata(result, region_markers, peak_markers, background_markers, bg_type, equal_sigma, free_position)
 
     # save the fit result to a temp file
     save_modelresult(result, 'temp_fit.sav')

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -649,24 +649,25 @@ def GaussianFit(counts: list, centers: list,
         raise ValueError('Unsupported background model')
     
     # Fit the background model to the data of the background markers before fitting the peaks
-    if len(background_markers) == 0:
+    if bg_type != 'None' and len(background_markers) == 0:
         # put marker at the start and end of the region
         background_markers = [(region_markers[0]-bin_width, region_markers[0]), (region_markers[1], region_markers[1]+bin_width)]
 
-    bg_x = []
-    bg_y = []
-    for bg_start, bg_end in background_markers:
-        # sort the background markers
-        bg_start, bg_end = sorted([bg_start, bg_end])
+    bg_result = None
+    if bg_type != 'None':
+        bg_x = []
+        bg_y = []
+        for bg_start, bg_end in background_markers:
+            # sort the background markers
+            bg_start, bg_end = sorted([bg_start, bg_end])
 
-        bg_mask = (centers >= bg_start) & (centers <= bg_end)
-        bg_x.extend(centers[bg_mask])
-        bg_y.extend(counts[bg_mask])
+            bg_mask = (centers >= bg_start) & (centers <= bg_end)
+            bg_x.extend(centers[bg_mask])
+            bg_y.extend(counts[bg_mask])
 
-    bg_x = np.array(bg_x)
-    bg_y = np.array(bg_y)
-    
-    bg_result = bg_model.fit(bg_y, params, x=bg_x)
+        bg_x = np.array(bg_x)
+        bg_y = np.array(bg_y)
+        bg_result = bg_model.fit(bg_y, params, x=bg_x)
 
     # print intial parameter guesses
     print('Initial Background Parameter Guesses:')
@@ -674,11 +675,15 @@ def GaussianFit(counts: list, centers: list,
 
     # print fit report
     print('Background Fit Report:')
-    print(bg_result.fit_report())
+    if bg_result is not None:
+        print(bg_result.fit_report())
+    else:
+        print('Background model set to None; skipping background fit.')
 
     # **Adjust background parameters based on their errors**
-    for param in bg_result.params:
-        params[param].set(value=bg_result.params[param].value, vary=False)
+    if bg_result is not None:
+        for param in bg_result.params:
+            params[param].set(value=bg_result.params[param].value, vary=False)
 
     # Add background model to overall model
     model = bg_model
@@ -886,7 +891,7 @@ def GaussianFit(counts: list, centers: list,
     fit_metadata = (
         list(region_markers),
         list(peak_markers),
-        list(background_markers),
+        [] if bg_type == 'None' else list(background_markers),
         bg_type,
         equal_sigma,
         free_position,
@@ -991,10 +996,7 @@ def load_result(filename: str):
         else:
             fallback_region = [float(x_min), float(x_max)]
         fallback_peak_markers = fitted_means if fitted_means else [float(p) for p in peak_markers]
-        fallback_background = [
-            (fallback_region[0] - bin_width, fallback_region[0]),
-            (fallback_region[1], fallback_region[1] + bin_width),
-        ]
+        fallback_background = []
         fit_metadata = (
             fallback_region,
             fallback_peak_markers,

--- a/src/fitter/models/gaussian.rs
+++ b/src/fitter/models/gaussian.rs
@@ -493,8 +493,67 @@ def _inject_spectrix_metadata(result, region_markers, peak_markers, background_m
     params.add('spectrix_meta_equal_sigma', value=1.0 if equal_sigma else 0.0, vary=False)
     params.add('spectrix_meta_free_position', value=1.0 if free_position else 0.0, vary=False)
 
+    # Python-friendly marker parameter names for external tools/scripts
+    params.add('region_marker_count', value=len(region_markers), vary=False)
+    for i, val in enumerate(region_markers):
+        params.add(f'region_marker_{i}', value=float(val), vary=False)
+
+    params.add('peak_marker_count', value=len(peak_markers), vary=False)
+    for i, val in enumerate(peak_markers):
+        params.add(f'peak_marker_{i}', value=float(val), vary=False)
+
+    params.add('bg_marker_count', value=len(background_markers), vary=False)
+    for i, (start, end) in enumerate(background_markers):
+        params.add(f'bg_marker_start_{i}', value=float(start), vary=False)
+        params.add(f'bg_marker_end_{i}', value=float(end), vary=False)
+
+    params.add('bg_model_type', value=float(_bg_type_to_code(bg_type)), vary=False)
+    params.add('fit_equal_sigma', value=1.0 if equal_sigma else 0.0, vary=False)
+    params.add('fit_free_position', value=1.0 if free_position else 0.0, vary=False)
+
 def _extract_spectrix_metadata(result):
     params = result.params
+    # Preferred: python-friendly marker parameter names
+    if 'region_marker_count' in params or 'peak_marker_count' in params or 'bg_marker_count' in params:
+        region_count = int(params['region_marker_count'].value) if 'region_marker_count' in params else 0
+        peak_count = int(params['peak_marker_count'].value) if 'peak_marker_count' in params else 0
+        bg_pair_count = int(params['bg_marker_count'].value) if 'bg_marker_count' in params else 0
+
+        region_markers = [
+            float(params[f'region_marker_{i}'].value)
+            for i in range(region_count)
+            if f'region_marker_{i}' in params
+        ]
+        peak_markers = [
+            float(params[f'peak_marker_{i}'].value)
+            for i in range(peak_count)
+            if f'peak_marker_{i}' in params
+        ]
+
+        background_markers = []
+        for i in range(bg_pair_count):
+            start_key = f'bg_marker_start_{i}'
+            end_key = f'bg_marker_end_{i}'
+            if start_key in params and end_key in params:
+                start = float(params[start_key].value)
+                end = float(params[end_key].value)
+                background_markers.append((start, end))
+
+        bg_type_code = float(params['bg_model_type'].value) if 'bg_model_type' in params else 0.0
+        equal_sigma = (float(params['fit_equal_sigma'].value) > 0.5) if 'fit_equal_sigma' in params else True
+        free_position = (float(params['fit_free_position'].value) > 0.5) if 'fit_free_position' in params else True
+
+        return (
+            region_markers,
+            peak_markers,
+            background_markers,
+            _code_to_bg_type(bg_type_code),
+            equal_sigma,
+            free_position,
+            True,
+        )
+
+    # Legacy SpectriX names
     if 'spectrix_meta_version' not in params:
         return None
 

--- a/src/histoer/histo1d/fitting.rs
+++ b/src/histoer/histo1d/fitting.rs
@@ -4,6 +4,20 @@ use crate::fitter::common::Data;
 use crate::fitter::main_fitter::{BackgroundModel, FitModel, FitResult, Fitter};
 
 impl Histogram {
+    pub fn apply_refit_all_request(&mut self) {
+        if !self.fits.take_pending_refit_all() {
+            return;
+        }
+
+        let fit_count = self.fits.stored_fits.len();
+        for _ in 0..fit_count {
+            self.fits.pending_modify_fit = Some(0);
+            self.apply_modify_fit_request();
+            self.fit_gaussians();
+            self.fits.store_temp_fit();
+        }
+    }
+
     pub fn apply_modify_fit_request(&mut self) {
         let Some(fit_idx) = self.fits.take_pending_modify_fit() else {
             return;

--- a/src/histoer/histo1d/fitting.rs
+++ b/src/histoer/histo1d/fitting.rs
@@ -9,14 +9,15 @@ impl Histogram {
             return;
         };
 
-        let Some((metadata, metadata_found, fallback_background_model)) = self
-            .fits
-            .stored_fits
-            .get(fit_idx)
-            .and_then(|stored_fit| {
+        let Some((metadata, metadata_found, fallback_background_model)) =
+            self.fits.stored_fits.get(fit_idx).and_then(|stored_fit| {
                 if let Some(FitResult::Gaussian(gaussian)) = &stored_fit.fit_result {
                     let (metadata, metadata_found) = gaussian.fit_metadata_with_fallback();
-                    Some((metadata, metadata_found, stored_fit.background_model.clone()))
+                    Some((
+                        metadata,
+                        metadata_found,
+                        stored_fit.background_model.clone(),
+                    ))
                 } else {
                     None
                 }

--- a/src/histoer/histo1d/fitting.rs
+++ b/src/histoer/histo1d/fitting.rs
@@ -9,16 +9,23 @@ impl Histogram {
             return;
         };
 
-        let Some(stored_fit) = self.fits.stored_fits.get(fit_idx) else {
-            return;
-        };
-
-        let Some(FitResult::Gaussian(gaussian)) = &stored_fit.fit_result else {
+        let Some((metadata, metadata_found, fallback_background_model)) = self
+            .fits
+            .stored_fits
+            .get(fit_idx)
+            .and_then(|stored_fit| {
+                if let Some(FitResult::Gaussian(gaussian)) = &stored_fit.fit_result {
+                    let (metadata, metadata_found) = gaussian.fit_metadata_with_fallback();
+                    Some((metadata, metadata_found, stored_fit.background_model.clone()))
+                } else {
+                    None
+                }
+            })
+        else {
             log::warn!("Modify fit requested for non-Gaussian fit.");
             return;
         };
 
-        let (metadata, metadata_found) = gaussian.fit_metadata_with_fallback();
         if !metadata_found {
             log::warn!(
                 "Fit metadata was not found; using fallback marker data derived from Gaussian parameters."
@@ -45,7 +52,7 @@ impl Histogram {
             "quadratic" => BackgroundModel::Quadratic(Default::default()),
             "exponential" => BackgroundModel::Exponential(Default::default()),
             "powerlaw" => BackgroundModel::PowerLaw(Default::default()),
-            _ => stored_fit.background_model.clone(),
+            _ => fallback_background_model,
         };
 
         self.fits.temp_fit = None;

--- a/src/histoer/histo1d/fitting.rs
+++ b/src/histoer/histo1d/fitting.rs
@@ -9,7 +9,7 @@ impl Histogram {
             return;
         };
 
-        let Some((metadata, metadata_found, fallback_background_model)) =
+        let Some((metadata, metadata_found, fallback_background_model, mut moved_fit)) =
             self.fits.stored_fits.get(fit_idx).and_then(|stored_fit| {
                 if let Some(FitResult::Gaussian(gaussian)) = &stored_fit.fit_result {
                     let (metadata, metadata_found) = gaussian.fit_metadata_with_fallback();
@@ -17,6 +17,7 @@ impl Histogram {
                         metadata,
                         metadata_found,
                         stored_fit.background_model.clone(),
+                        stored_fit.clone(),
                     ))
                 } else {
                     None
@@ -43,20 +44,31 @@ impl Histogram {
         for marker in metadata.peak_markers {
             self.plot_settings.markers.add_peak_marker(marker);
         }
-        self.plot_settings
-            .markers
-            .set_background_marker_positions(&metadata.background_markers);
-        self.update_background_pair_lines();
 
         self.fits.settings.background_model = match metadata.background_model.as_str() {
             "linear" => BackgroundModel::Linear(Default::default()),
             "quadratic" => BackgroundModel::Quadratic(Default::default()),
             "exponential" => BackgroundModel::Exponential(Default::default()),
             "powerlaw" => BackgroundModel::PowerLaw(Default::default()),
+            "None" => BackgroundModel::None,
             _ => fallback_background_model,
         };
 
-        self.fits.temp_fit = None;
+        if matches!(self.fits.settings.background_model, BackgroundModel::None) {
+            self.plot_settings.markers.clear_background_markers();
+        } else {
+            self.plot_settings
+                .markers
+                .set_background_marker_positions(&metadata.background_markers);
+            self.update_background_pair_lines();
+        }
+
+        if fit_idx < self.fits.stored_fits.len() {
+            self.fits.stored_fits.remove(fit_idx);
+        }
+
+        moved_fit.name = format!("{} (Temp)", moved_fit.name);
+        self.fits.temp_fit = Some(moved_fit);
     }
 
     pub fn fit_background(&mut self) {

--- a/src/histoer/histo1d/fitting.rs
+++ b/src/histoer/histo1d/fitting.rs
@@ -112,6 +112,30 @@ impl Histogram {
     }
 
     pub fn fit_gaussians(&mut self) {
+        let previous_peak_assignments = self
+            .fits
+            .temp_fit
+            .as_ref()
+            .and_then(|temp_fit| match &temp_fit.fit_result {
+                Some(FitResult::Gaussian(g)) => Some(
+                    g.fit_result
+                        .iter()
+                        .filter_map(|p| {
+                            p.mean.value.map(|m| {
+                                (
+                                    m,
+                                    p.uuid,
+                                    p.energy.value.unwrap_or(-1.0),
+                                    p.energy.uncertainty.unwrap_or(0.0),
+                                )
+                            })
+                        })
+                        .collect::<Vec<_>>(),
+                ),
+                _ => None,
+            })
+            .unwrap_or_default();
+
         let region_markers = self.plot_settings.markers.get_region_marker_positions();
         let peak_positions = self.plot_settings.markers.get_peak_marker_positions();
         let background_markers = self.plot_settings.markers.get_background_marker_positions();
@@ -171,6 +195,34 @@ impl Histogram {
 
         fitter.set_name(self.name.clone());
         self.fits.temp_fit = Some(fitter);
+
+        // Preserve UUID and energy assignments across modify -> refit workflows.
+        if !previous_peak_assignments.is_empty()
+            && let Some(temp_fit) = &mut self.fits.temp_fit
+            && let Some(FitResult::Gaussian(g)) = &mut temp_fit.fit_result
+        {
+            let mut prev_sorted = previous_peak_assignments.clone();
+            prev_sorted.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+
+            let mut new_sorted: Vec<(usize, f64)> = g
+                .fit_result
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, p)| p.mean.value.map(|m| (idx, m)))
+                .collect();
+            new_sorted.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+            for ((new_idx, _), (_, uuid, energy, energy_unc)) in
+                new_sorted.into_iter().zip(prev_sorted.into_iter())
+            {
+                if let Err(e) = g.update_uuid_for_peak(new_idx, uuid) {
+                    log::warn!("Failed to preserve UUID for peak {new_idx}: {e}");
+                }
+                if let Err(e) = g.update_energy_for_peak(new_idx, energy, energy_unc) {
+                    log::warn!("Failed to preserve energy for peak {new_idx}: {e}");
+                }
+            }
+        }
 
         // calibrate temp fit if calibration is enabled
         if self.fits.settings.calibrated

--- a/src/histoer/histo1d/fitting.rs
+++ b/src/histoer/histo1d/fitting.rs
@@ -188,7 +188,14 @@ impl Histogram {
         fitter.fit();
 
         self.plot_settings.markers.clear_peak_markers();
-        let updated_markers = fitter.get_peak_markers();
+        let updated_markers = if let Some(FitResult::Gaussian(g)) = &fitter.fit_result {
+            g.fit_result
+                .iter()
+                .filter_map(|p| p.mean.value)
+                .collect::<Vec<_>>()
+        } else {
+            fitter.get_peak_markers()
+        };
         for marker in updated_markers {
             self.plot_settings.markers.add_peak_marker(marker);
         }

--- a/src/histoer/histo1d/fitting.rs
+++ b/src/histoer/histo1d/fitting.rs
@@ -1,9 +1,56 @@
 use super::histogram1d::Histogram;
 
 use crate::fitter::common::Data;
-use crate::fitter::main_fitter::{FitModel, Fitter};
+use crate::fitter::main_fitter::{BackgroundModel, FitModel, FitResult, Fitter};
 
 impl Histogram {
+    pub fn apply_modify_fit_request(&mut self) {
+        let Some(fit_idx) = self.fits.take_pending_modify_fit() else {
+            return;
+        };
+
+        let Some(stored_fit) = self.fits.stored_fits.get(fit_idx) else {
+            return;
+        };
+
+        let Some(FitResult::Gaussian(gaussian)) = &stored_fit.fit_result else {
+            log::warn!("Modify fit requested for non-Gaussian fit.");
+            return;
+        };
+
+        let (metadata, metadata_found) = gaussian.fit_metadata_with_fallback();
+        if !metadata_found {
+            log::warn!(
+                "Fit metadata was not found; using fallback marker data derived from Gaussian parameters."
+            );
+        }
+
+        self.plot_settings.markers.clear_background_markers();
+        self.plot_settings.markers.clear_peak_markers();
+        self.plot_settings.markers.clear_region_markers();
+
+        for marker in metadata.region_markers {
+            self.plot_settings.markers.add_region_marker(marker);
+        }
+        for marker in metadata.peak_markers {
+            self.plot_settings.markers.add_peak_marker(marker);
+        }
+        self.plot_settings
+            .markers
+            .set_background_marker_positions(&metadata.background_markers);
+        self.update_background_pair_lines();
+
+        self.fits.settings.background_model = match metadata.background_model.as_str() {
+            "linear" => BackgroundModel::Linear(Default::default()),
+            "quadratic" => BackgroundModel::Quadratic(Default::default()),
+            "exponential" => BackgroundModel::Exponential(Default::default()),
+            "powerlaw" => BackgroundModel::PowerLaw(Default::default()),
+            _ => stored_fit.background_model.clone(),
+        };
+
+        self.fits.temp_fit = None;
+    }
+
     pub fn fit_background(&mut self) {
         log::info!("Fitting background for histogram: {}", self.name);
         self.fits.temp_fit = None;

--- a/src/histoer/histo1d/histogram1d.rs
+++ b/src/histoer/histo1d/histogram1d.rs
@@ -150,6 +150,7 @@ impl Histogram {
                 if show_stats {
                     row.col(|ui| {
                         self.fits.ui(ui, true);
+                        self.apply_modify_fit_request();
                         width -= ui.available_width(); // assign the difference back to `width`
                     });
                 }

--- a/src/histoer/histo1d/histogram1d.rs
+++ b/src/histoer/histo1d/histogram1d.rs
@@ -150,6 +150,7 @@ impl Histogram {
                 if show_stats {
                     row.col(|ui| {
                         self.fits.ui(ui, true);
+                        self.apply_refit_all_request();
                         self.apply_modify_fit_request();
                         width -= ui.available_width(); // assign the difference back to `width`
                     });

--- a/src/histoer/histo1d/markers.rs
+++ b/src/histoer/histo1d/markers.rs
@@ -222,6 +222,23 @@ impl FitMarkers {
         self.background_markers.clear();
     }
 
+    pub fn set_background_marker_positions(&mut self, markers: &[(f64, f64)]) {
+        self.background_markers.clear();
+
+        for (idx, &(start, end)) in markers.iter().enumerate() {
+            let mut marker_start = EguiVerticalLine::new(start, egui::Color32::from_rgb(0, 200, 0));
+            let mut marker_end = EguiVerticalLine::new(end, egui::Color32::from_rgb(0, 200, 0));
+
+            marker_start.width = 0.5;
+            marker_end.width = 0.5;
+            marker_start.name = format!("Background Pair {idx} Start");
+            marker_end.name = format!("Background Pair {idx} End");
+
+            self.background_markers
+                .push(BackgroundPair::new(marker_start, marker_end));
+        }
+    }
+
     fn delete_marker(markers: &mut Vec<EguiVerticalLine>, marker_to_delete: f64) {
         if let Some(index) = markers.iter().position(|x| x.x_value == marker_to_delete) {
             markers.remove(index);


### PR DESCRIPTION
### Motivation

- Provide a way for users to click a `Modify` button on a stored fit row to clear existing markers and restore the exact region/peak/background markers and background model used when the fit was created.
- Persist the marker and fit configuration into the lmfit `.sav` payload so marker positions and background settings are accessible when loading a saved lmfit result.
- When metadata is missing (older `.sav`), warn the user and generate sensible fallback marker data from the Gaussian fit so modification still works.

### Description

- Added `GaussianFitMetadata` and a `fit_metadata: Option<GaussianFitMetadata>` field to `GaussianFitter`, plus a `fit_metadata_with_fallback` helper that returns metadata and whether it was found in the save.
- Extended the embedded Python `GaussianFit`/`load_result` flow to inject `_inject_spectrix_metadata` into the `lmfit` result parameters and to `_extract_spectrix_metadata` on load, and return `fit_metadata` from the Python wrapper to Rust.
- Introduced `set_background_marker_positions` in `FitMarkers` to restore exact background `(start,end)` pairs, added `BackgroundModel::type_name()` to round-trip the background model as a string, and implemented fallback metadata generation when no metadata is found.
- Added a pending modify workflow: `Fits.pending_modify_fit` + `take_pending_modify_fit()`, a `Modify` button in the fit table that sets the pending index, and `Histogram::apply_modify_fit_request()` which clears existing markers, sets region/peak/background markers from the stored fit metadata, refreshes background lines (`update_background_pair_lines()`), restores background model settings, and clears `temp_fit`.

### Testing

- Ran `cargo fmt` successfully (no formatting changes outstanding).
- Ran `cargo check` in this environment but the dependency build ran long and the run timed out before completing, and no compile errors were produced prior to timeout.
- No other automated tests were executed in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c45c2f35d88327bf4e86a520698db9)